### PR TITLE
Fix VARA-RMS TCP port connection issue (for https://github.com/WheezyE/Winelink/issues/17)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,6 @@ curl -O https://raw.githubusercontent.com/WheezyE/Winelink/main/install_winelink
      bash install_winelink.sh
 ```
  - A full installation takes about 30 minutes (with user prompts) and lots of errors will appear in the terminal (just ignore those).
- - You should then be able to run RMS Express and VARA from desktop shortcuts.  They may crash.
  - If desired, you can tell the script to only install VARA by running `curl -O https://raw.githubusercontent.com/WheezyE/Winelink/main/install_winelink.sh && bash install_winelink.sh vara_only`
 
 ## Examples
@@ -24,9 +23,8 @@ This script will help you install Box86, Wine, winetricks, Windows DLL's, RMS Ex
 To run Windows .exe files on RPi4 (ARM/Linux), we need an x86 emulator ([Box86](https://github.com/ptitSeb/box86)) and a Windows API Call interpreter ([Wine](https://github.com/wine-mirror/wine)).  Box86 is open-source and runs about 10x faster than [ExaGear](https://www.huaweicloud.com/kunpeng/software/exagear.html) or [Qemu](https://github.com/qemu/qemu).  ExaGear is also closed source abandonware and Qemu (qemu-system & qemu-user-static) also has issues running more complex Wine programs on the Pi.  Box86 is much smaller in file size and much easier to install too.
 
 ## Known issues
- - ARDOP often has trouble connecting to RMS Express over TCP when if first starts. If ARDOP fails to connect, just restart it until it does connect (this is a bug in wine).
+ - ARDOP & VARA often have trouble connecting to RMS Express over TCP when they first start. If ARDOP fails to connect, just restart RMS Express it until it does connect (this is a bug in wine).
  - VARA's CPU gauge doesn't display (this is a bug in wine).
- - Using the map can cause RMS Express to crash.
  - I haven't tested over-the-air connections since I'm just a tech.  If some generals could test, that would be awesome.
  - RMS Express v1.5.41.0 introduced a requirement for .NET 4.6 (instead of just .NET 3.5sp1). This updated has forced us to use wine-mono instead of .NET.  Wine-mono may have some bugs. Madewokherd (Esme), the wine-mono dev, is amazing though - they have fixed all of the bugs we've encountered so far.
     

--- a/install_winelink.sh
+++ b/install_winelink.sh
@@ -6,7 +6,7 @@ function run_greeting()
     echo ""
     echo "########### Winlink & VARA Installer Script for the Raspberry Pi 4B ###########"
     echo "# Author: Eric Wiessner (KI7POL)                    Install time: apx 30 min  #"
-    echo "# Version: 0.0085a (Work in progress)                                         #"
+    echo "# Version: 0.0086a (Work in progress)                                         #"
     echo "# Credits:                                                                    #"
     echo "#   The Box86 team (ptitSeb, pale, chills340, Itai-Nelken, Heasterian, et al) #"
     echo "#   Esme 'madewokherd' Povirk (CodeWeavers) for wine-mono debugging/support   #"
@@ -76,9 +76,9 @@ function run_main()
         
         ### Install Wine & winetricks
             rm ~/Desktop/Reset\ Wine ~/Desktop/VARA.desktop ~/Desktop/VARA\ Chat.desktop ~/Desktop/VARA\ FM.desktop ~/Desktop/Winlink\ Express.desktop 2>/dev/null # remove old winlink/wine desktop shortcuts (in case we are reinstalling wine)
-            run_installwine "pi4" "devel" "6.19~${VERSION_CODENAME}-1" "${VERSION_CODENAME}" # windows API-call interperter for non-windows OS's - freeze version to ensure compatability
+            run_installwine "pi4" "devel" "7.1~${VERSION_CODENAME}-1" "${VERSION_CODENAME}" # windows API-call interperter for non-windows OS's - freeze version to ensure compatability
             run_installwinetricks # software installer script for wine
-            run_downloadbox86 31_Jan_22 # emulator to run wine-i386 on ARM - freeze version to ensure compatability
+            run_downloadbox86 10_Dec_21 # emulator to run wine-i386 on ARM - freeze version to ensure compatability
             
         ### Set up Wine (silently make & configure a new wineprefix)
             if [ "$ARG" = "vara_only" ]; then
@@ -253,6 +253,7 @@ function run_installwine()  # Download and install Wine for i386 Debian Buster (
     local branch="$2" #example: "devel" or "stable" without quotes (staging requires more install steps)  ${version}
     local version="$3" #example: "6.19~buster-1"
     local dist="$4" #example: buster
+    local build="$5" #example: debian
 
     wineserver -k &> /dev/null # stop any old wine installations from running - TODO: double-check this command
     rm -rf ~/.cache/wine # remove any old wine-mono or wine-gecko install files in case wine was installed previously
@@ -498,15 +499,15 @@ function run_installvara()  # Download / extract / install VARA HF/FM/Chat, then
             sed -i 's+View\=1+View\=3+g' ~/.wine/drive_c/VARA\ FM/VARAFM.ini # turn off VARA FM's graphics (change 'View=1' to 'View=3' in VARAFM.ini). INI file shows up after first run of VARA FM.
     cd ..
     
-    ## Fix some VARA graphics glitches caused by Wine's (winecfg) window manager (otherwise VARA appears as a black screen when auto-run by RMS Express)
+    ## In older versions of wine, this fixed graphics glitches caused by Wine's (winecfg) window manager (VARA appeared as a black screen when auto-run by RMS Express)
         # NOTE: If using dotnet (instead of wine-mono) on Pi, this will slow things down a lot
         # Create override-x11.reg
-        echo 'REGEDIT4'                                      >> override-x11.reg
-        echo ''                                              >> override-x11.reg
-        echo '[HKEY_CURRENT_USER\Software\Wine\X11 Driver]'  >> override-x11.reg
-        echo '"Decorated"="Y"'                               >> override-x11.reg
-        echo '"Managed"="N"'                                 >> override-x11.reg
-        wine cmd /c regedit /s override-x11.reg
+        #echo 'REGEDIT4'                                      >> override-x11.reg
+        #echo ''                                              >> override-x11.reg
+        #echo '[HKEY_CURRENT_USER\Software\Wine\X11 Driver]'  >> override-x11.reg
+        #echo '"Decorated"="Y"'                               >> override-x11.reg
+        #echo '"Managed"="N"'                                 >> override-x11.reg
+        #wine cmd /c regedit /s override-x11.reg
 }
 
 function run_installvARIM()  # Download, build, and install an open-source stand-alone interface for VARA, called vARIM


### PR DESCRIPTION
 - Bump wine version to 7.1
 - Re-enable wine window manager since VARA graphics glitches are gone in newer versions of wine (tested wine-devel-7.1)
 - Go back to older version of box86 (versions after ed8e01ea cause wine7.1 errors and TCP connection issues with VARA)
 - Maps work again (fixed by either newer wine or different box86)