### PR TITLE
Small updates to README.md & install_winelink.sh

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,10 +23,10 @@ This script will help you install Box86, Wine, winetricks, Windows DLL's, RMS Ex
 To run Windows .exe files on RPi4 (ARM/Linux), we need an x86 emulator ([Box86](https://github.com/ptitSeb/box86)) and a Windows API Call interpreter ([Wine](https://github.com/wine-mirror/wine)).  Box86 is open-source and runs about 10x faster than [ExaGear](https://www.huaweicloud.com/kunpeng/software/exagear.html) or [Qemu](https://github.com/qemu/qemu).  ExaGear is also closed source abandonware and Qemu (qemu-system & qemu-user-static) also has issues running more complex Wine programs on the Pi.  Box86 is much smaller in file size and much easier to install too.
 
 ## Known issues
- - ARDOP & VARA often have trouble connecting to RMS Express over TCP when they first start. If ARDOP fails to connect, just restart RMS Express it until it does connect (this is a bug in wine).
+ - ARDOP & VARA often have trouble connecting to RMS Express (over local TCP) when they first start up. Just restart RMS Express until they do connect (this is a bug in wine).
  - VARA's CPU gauge doesn't display (this is a bug in wine).
- - I haven't tested over-the-air connections since I'm just a tech.  If some generals could test, that would be awesome.
- - RMS Express v1.5.41.0 introduced a requirement for .NET 4.6 (instead of just .NET 3.5sp1). This updated has forced us to use wine-mono instead of .NET.  Wine-mono may have some bugs. Madewokherd (Esme), the wine-mono dev, is amazing though - they have fixed all of the bugs we've encountered so far.
+ - VARA doesn't connect to DRA boards at this time. This might be a bug in box86 or wine.
+ - Enabling VARA HF's waterfally display can sometimes crash VARA & RMS Express.
     
 ## Credits
  - [ptitSeb](https://github.com/ptitSeb/box86) for box86 debugging (& everyone on [the TwisterOS discord](https://discord.gg/Fh8sjmu))
@@ -36,7 +36,7 @@ To run Windows .exe files on RPi4 (ARM/Linux), we need an x86 emulator ([Box86](
 
  - [madewokherd](https://github.com/madewokherd/wine-mono) (Esme) for wine-mono debugging
  - N7ACW, AD7HE, & KK6FVG for getting me started in ham radio
- - [KM4ACK](https://github.com/km4ack/pi-build) & OH8STN for inspiration
+ - [KM4ACK](https://github.com/km4ack/pi-build) & [OH8STN](https://oh8stn.org/) for inspiration
  - [K6ETA](http://k6eta.com/linux/installing-rms-express-on-linux-with-wine) & [DCJ21](https://dcj21net.wordpress.com/2016/06/17/install-rms-express-linux/)'s 'Winlink on Linux' guides for early proof-of-concept
 
          "My humanity is bound up in yours, for we can only be human together"
@@ -46,13 +46,19 @@ To run Windows .exe files on RPi4 (ARM/Linux), we need an x86 emulator ([Box86](
 All software used by this script is free and legal to use (with the exception of VARA, of course, which is shareware).  Box86, Wine, wine-mono, winetricks, and AutoHotKey, are all open-source (which avoids the legal problems of use & distribution that ExaGear had - ExaGear also ran much slower than Box86 and is no-longer maintained, despite what Huawei says these days).  All proprietary Windows DLL files required by Wine are downloaded directly from Microsoft and installed according to their redistribution guidelines.  Raspberry Pi is a trademark of the Raspberry Pi Foundation
 
 ## Future work
- - [ ] Add updated example images.
+ - [ ] Separate soundcard setups from program installations. Make a script for that.
+ - [ ] Put program scripts and icons into start menu instead of on desktop.
  - [ ] Add an AHK script to help the user with ARDOP first time soundcard setup.
+ - [ ] Switch to using Seb's GitHub box86 binaries instead of Pale's internet archive binaries.
+ - [ ] Help DRA-board compatability with VARA ([might be a box86 issue?](https://github.com/ptitSeb/box86/issues/567))
+ - [ ] Bisect box86 commits that crash VARA's local TCP to RMS connection (bug in newer box86's)
+ - [ ] Add updated example images.
  - [ ] Consider adding a sed script to find/delete any small-value frequencies in `RMS Channels.dat` that would crash the HF Channel Selection Browser
  - [ ] Clean up code with [Google style guide](https://google.github.io/styleguide/shellguide.html).
- - [ ] Work with the Wine team to [figure out why VARA's CPU gauge isn't working](https://bugs.winehq.org/show_bug.cgi?id=50728).
- - [ ] Work with the Wine team to [figure out why ARDOP & VARA don't always connect to RMS Express over TCP when first starting](https://bugs.winehq.org/show_bug.cgi?id=52521).
+ - [ ] Work with WineHQ to [figure out why VARA's CPU gauge isn't working](https://bugs.winehq.org/show_bug.cgi?id=50728).
+ - [ ] Work with WineHQ to [figure out why ARDOP & VARA don't always connect to RMS Express over TCP when first starting](https://bugs.winehq.org/show_bug.cgi?id=52521).
  - [ ] Add 'splash screen' to RMS Express desktop shortcut (since launching takes a while)
+ - [ ] Add progress bar (GUI?) for installation.
  - [x] Rely on [archive.org box86 binaries](https://archive.org/details/box86.7z_20200928) instead of compiling.
     - [ ] Give user the choice to compile or not.
     - [ ] Add auto-detection of failed downloads, then switch to compiling as contingency.
@@ -86,7 +92,8 @@ All software used by this script is free and legal to use (with the exception of
  #### Add more platforms (make a multi-platform [Wine](https://wiki.winehq.org/Download) installer & build/invoke box86 if needed).
  - [x] Auto-detection of system arch (x86 vs armhf vs aarch64) & OS.
     - ARM
-      - [x] Raspberry Pi 4B
+      - [x] Raspberry Pi 4B (32-bit OS)
+      - [ ] Raspberry Pi 4B (64-bit OS)
       - [ ] Raspberry Pi 3B+
         - [ ] Detect Raspberry Pi kernel memory split (and install the correct kernel if needed) for RPi <4 support.
         - [ ] Ask Botspot if I can borrow some of his [pi-apps code](https://github.com/Botspot/pi-apps/blob/4a48ba62b157420c6e33666e7d050ee3ce21ab0b/apps/Wine%20(x86)/install-32#L165).
@@ -94,40 +101,45 @@ All software used by this script is free and legal to use (with the exception of
       - [ ] RPi Zero W?
       - [ ] [Termux](https://github.com/termux/termux-app) (Android without root) ([proot-distro](https://github.com/termux/proot-distro) + Ubuntu ARM + [termux-usb](https://wiki.termux.com/wiki/Termux-usb)) - see [AnBox86](https://github.com/lowspecman420/AnBox86) for proof of concept, currently untested with VARA.
         - [x] Fix AnBox86
+        - [x] [Proof-of-concept](https://www.youtube.com/watch?v=FkeP_IW3GGQ&t=29s)
+        - [ ] ~See if termux-usb can be adapted somehow to allow connections without root?~
+      - [ ] [Box86Launcher](https://github.com/AllPlatform/Box86Launcher) (Android -- root?)
+      - [ ] Mac M1 processors
     - x86
       - Mac
         - [ ] OSX?
-      - Linux
-        - [ ] Debian (Package manager: apt)
-          - [ ] Deepin
-          - [ ] Kali
+      - Linux (top priorities are distros that WineHQ hosts binaries for: Ubuntu, Debian, Fedora, macOS, SUSE, Slackware, and FreeBSD)
         - [ ] Ubuntu (Package manager: apt)
           - [x] Linux Mint
           - [ ] Elementary OS
           - [ ] Zorin OS
+        - [ ] Debian (Package manager: apt)
+          - [ ] Deepin
+          - [ ] Kali
+        - [ ] Red Hat (Package manager: yum, RPM)
+          - [ ] Fedora (Package manager: RPM/DNF)
+          - [ ] CentOS (Package manager: yum)
+        - [ ] openSUSE (Package manager: ZYpp (standard); YaST (front-end); RPM (low-level))
+        - [ ] Slackware (Package manager: pkgtool, slackpkg)
+        - [ ] FreeBSD (Package manager: pkg)
         - [ ] Arch (Package manager: pacman, libalpm)
           - [ ] Vanilla Arch??
           - [ ] Manjaro
           - [ ] XeroLinux
           - [ ] SteamOS? (Steam Deck)
-        - [ ] Red Hat (Package manager: yum, RPM)
-          - [ ] Fedora (Package manager: RPM/DNF)
-          - [ ] CentOS (Package manager: yum)
-        - [ ] Slackware (Package manager: pkgtool, slackpkg)
-        - [ ] FreeBSD (Package manager: pkg)
         - [ ] Gentoo (Package manager: Portage)
         - [ ] Solus (Package manager: eopkg)
-        - [ ] openSUSE (Package manager: ZYpp (standard); YaST (front-end); RPM (low-level))
       - [ ] ChromeBook Linux beta.
         - [ ] Try to detect if processor would be too slow?
  - [ ] Make a youtube video showcasing current methods (box86, Exagear issues, qemu-user-static errors, Pi4B, Pi3B+, Termux, Mac, Linux, ChromeOS)
  
  - Android testing notes (Termux/PRoot/AnBox86_64)
-     - [x] Proof of concept https://youtu.be/FkeP_IW3GGQ?t=23
-     - [x] Audio in/out (ARDOP works with alsa / hiccups with pulseaudio)
-     - [ ] Speed benchmarks with different devices (Fire HD10 Tablet is a bit slow, Retroid Pocket 2 TBD)
-     - [ ] OTG-USB-CAT (order OTG_USB_C-USB)
+     - [ ] Termux-usb seems to need root to really work. See if there is a work-around for no root?
      - [ ] Create alpha version of Winelink for AnBox86_64
+     - [ ] Speed benchmarks with different devices (Fire HD10 Tablet is a bit slow, Retroid Pocket 2 TBD)
+     - [x] OTG-USB-CAT (order OTG_USB_C-USB)
+     - [x] Audio in/out (ARDOP works with alsa / hiccups with pulseaudio)
+     - [x] Proof of concept https://youtu.be/FkeP_IW3GGQ?t=23
 
 ## Distribution
 If you use this script in your project (or are inspired by it) just please be sure to mention ptitSeb, Box86, and myself (KI7POL).  This script is free to use, open-source, and should not be monetized (for further information see the [license file](LICENSE)).
@@ -135,5 +147,5 @@ If you use this script in your project (or are inspired by it) just please be su
 ## Donations
 If you feel that you are able and would like to support this project, please consider sending donations to ptitSeb, madewokherd (CodeWeavers/WineHQ), or KM4ACK - without whom, this script would not exist.
  - Sebastien "ptitSeb" Chevalier (author of [Box86](https://github.com/ptitSeb/box86), incredible developer, & really nice guy) [paypal.me/0ptitSeb](paypal.me/0ptitSeb)
- - Madewokherd (author [wine-mono](https://github.com/madewokherd/wine-mono) & a wonderful person) [https://www.winehq.org/donate](https://www.winehq.org/donate)
+ - Madewokherd (author of [wine-mono](https://github.com/madewokherd/wine-mono) & wonderful person) [https://www.winehq.org/donate](https://www.winehq.org/donate)
  - Jason "KM4ACK" Oleham (author of [Build-a-Pi](https://github.com/km4ack/pi-build), Linux elmer, & ham radio pioneer) [paypal.me/km4ack](paypal.me/km4ack)


### PR DESCRIPTION
Update README.md
 - Add more goals & known bugs.
Update install_winelink.sh
 - Fix typo (use apt-get instead of apt)
 - simplify the vara_only subroutines a bit
 - Use wine-mono-7.1.3 official release (includes the COM port fix from the nightly build)