### PR TITLE
Add BAP compatability to Winelink

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Copy/paste these commands into your Raspberry Pi 4's terminal:
 curl -O https://raw.githubusercontent.com/WheezyE/Winelink/main/install_winelink.sh && \
      bash install_winelink.sh
 ```
- - A full installation takes about 30 minutes (with user prompts) and lots of errors will appear in the terminal (just ignore those).
+ - A full installation takes about 10 minutes (with user prompts)
  - If desired, you can tell the script to only install VARA by running `curl -O https://raw.githubusercontent.com/WheezyE/Winelink/main/install_winelink.sh && bash install_winelink.sh vara_only`
 
 ## Examples
@@ -25,8 +25,8 @@ To run Windows .exe files on RPi4 (ARM/Linux), we need an x86 emulator ([Box86](
 ## Known issues
  - ARDOP & VARA often have trouble connecting to RMS Express (over local TCP) when they first start up. Just restart RMS Express until they do connect (this is a bug in wine).
  - VARA's CPU gauge doesn't display (this is a bug in wine).
- - VARA doesn't connect to DRA boards at this time. This might be a bug in box86 or wine.
- - Enabling VARA HF's waterfally display can sometimes crash VARA & RMS Express.
+ - VARA doesn't connect to DRA boards at this time (this might be a bug in wine or box86).
+ - Enabling VARA HF's waterfall display can sometimes crash VARA & RMS Express.
     
 ## Credits
  - [ptitSeb](https://github.com/ptitSeb/box86) for box86 debugging (& everyone on [the TwisterOS discord](https://discord.gg/Fh8sjmu))
@@ -46,8 +46,6 @@ To run Windows .exe files on RPi4 (ARM/Linux), we need an x86 emulator ([Box86](
 All software used by this script is free and legal to use (with the exception of VARA, of course, which is shareware).  Box86, Wine, wine-mono, winetricks, and AutoHotKey, are all open-source (which avoids the legal problems of use & distribution that ExaGear had - ExaGear also ran much slower than Box86 and is no-longer maintained, despite what Huawei says these days).  All proprietary Windows DLL files required by Wine are downloaded directly from Microsoft and installed according to their redistribution guidelines.  Raspberry Pi is a trademark of the Raspberry Pi Foundation
 
 ## Future work
- - [ ] Separate soundcard setups from program installations. Make a script for that.
- - [ ] Put program scripts and icons into start menu instead of on desktop.
  - [ ] Add an AHK script to help the user with ARDOP first time soundcard setup.
  - [ ] Switch to using Seb's GitHub box86 binaries instead of Pale's internet archive binaries.
  - [ ] Help DRA-board compatability with VARA ([might be a box86 issue?](https://github.com/ptitSeb/box86/issues/567))
@@ -57,11 +55,13 @@ All software used by this script is free and legal to use (with the exception of
  - [ ] Clean up code with [Google style guide](https://google.github.io/styleguide/shellguide.html).
  - [ ] Work with WineHQ to [figure out why VARA's CPU gauge isn't working](https://bugs.winehq.org/show_bug.cgi?id=50728).
  - [ ] Work with WineHQ to [figure out why ARDOP & VARA don't always connect to RMS Express over TCP when first starting](https://bugs.winehq.org/show_bug.cgi?id=52521).
- - [ ] Add 'splash screen' to RMS Express desktop shortcut (since launching takes a while)
  - [ ] Add progress bar (GUI?) for installation.
  - [x] Rely on [archive.org box86 binaries](https://archive.org/details/box86.7z_20200928) instead of compiling.
     - [ ] Give user the choice to compile or not.
     - [ ] Add auto-detection of failed downloads, then switch to compiling as contingency.
+ - [x] Separate soundcard setups from program installations. Make a script for that.
+ - [x] Make an uninstaller script
+ - [x] Put program scripts and icons into start menu instead of on desktop.
  - [x] Test COM port connections to radio ("CAT" control, PTT).
  - [x] Work with madewokherd to see if wine-mono bugs can be fixed (would drastically improve install speed).
     - [x] [ARDOP TCP/IP Connection issues](https://github.com/madewokherd/wine-mono/issues/116).

--- a/install_winelink.sh
+++ b/install_winelink.sh
@@ -5,14 +5,14 @@ function run_greeting()
     clear
     echo ""
     echo "########### Winlink & VARA Installer Script for the Raspberry Pi 4B ###########"
-    echo "# Author: Eric Wiessner (KI7POL)                    Install time: apx 30 min  #"
-    echo "# Version: 0.0089a (Work in progress)                                         #"
+    echo "# Author: Eric Wiessner (KI7POL)                    Install time: apx 10 min  #"
+    echo "# Version: 0.0090a                                                            #"
     echo "# Credits:                                                                    #"
     echo "#   The Box86 team (ptitSeb, pale, chills340, Itai-Nelken, Heasterian, et al) #"
     echo "#   Esme 'madewokherd' Povirk (CodeWeavers) for wine-mono debugging/support   #"
     echo "#   N7ACW, AD7HE, & KK6FVG for getting me started in ham radio                #"
-    echo "#   KM4ACK & OH8STN for inspiration                                           #"
     echo "#   K6ETA & DCJ21's Winlink on Linux guides                                   #"
+    echo "#   KM4ACK & OH8STN for inspiration                                           #"
     echo "#                                                                             #"
     echo "#    \"My humanity is bound up in yours, for we can only be human together\"    #"
     echo "#                                                - Nelson Mandela             #"
@@ -24,8 +24,6 @@ function run_greeting()
     echo "#    - Support Esme & CodeWeavers: https://www.codeweavers.com/crossover -    #"
     echo "#       - Donate to Wine / wine-mono:  https://www.winehq.org/donate -        #"
     echo "###############################################################################"
-    read -n 1 -s -r -p "Press any key to continue . . ."
-    clear
 }
 
 # About:
@@ -37,7 +35,7 @@ function run_greeting()
 #    To run Windows .exe files on RPi4, we need an x86 emulator (box86) and a Windows API Call interpreter (wine).
 #    Box86 is opensource and runs about 10x faster than ExaGear or Qemu.  It's much smaller and easier to install too.
 #
-#    This installer should take about 30 minutes on a Raspberry Pi 4B.
+#    This installer should take about 10 minutes on a Raspberry Pi 4B.
 #
 # Distribution:
 #    This script is free to use, open-source, and should not be monetized.  If you use this script in your project (or are inspired by it) just please be sure to mention ptitSeb, Box86, and myself (KI7POL).
@@ -63,28 +61,46 @@ function run_greeting()
 
 function run_main()
 {
-        local ARG="$1" # store the first argument passed to the script file as a variable here (i.e. 'bash install_winelink.sh vara_only')
-
+    export WINEDEBUG=-all # silence winedbg for this instance of the terminal
+    local ARG="$1" # store the first argument passed to the script file as a variable here (i.e. 'bash install_winelink.sh vara_only')
+    
+    ### Clean up previous runs (or failed runs) of this script
+        sudo rm install_winelink.sh 2>/dev/null # silently remove this script so it cannot be re-run by accident
+        sudo rm -rf ${HOME}/winelink 2>/dev/null # silently clean up any failed past runs of this script
+        sudo rm ${STARTMENU}/resetwine.desktop ${STARTMENU}/vara-update.desktop ${STARTMENU}/vara.desktop ${STARTMENU}/vara-chat.desktop \
+                ${STARTMENU}/vara-fm.desktop ${STARTMENU}/winlinkexpress.desktop ${STARTMENU}/vara-soundcardsetup.desktop 2>/dev/null # remove old shortcuts
+        
+    ### Create winelink directory
+        mkdir ${HOME}/winelink && cd ${HOME}/winelink # store all downloaded/installed files in their own directory
+    
         ### Pre-installation
-            exec > >(tee "../winelink.log") 2>&1 # start logging
+            exec > >(tee "winelink.log") 2>&1 # start logging
             run_checkpermissions
             run_checkxhost
             run_gather_os_info
             #run_detect_arch # TODO: Customize this section to install wine for different operating systems.
-            rm -rf Winelink-tmp winelink.log 2>/dev/null; mkdir Winelink-tmp && cd Winelink-tmp # clean up any failed past runs of this script
-            rm ~/Desktop/Reset\ Wine ~/Desktop/Update\ VARA ~/Desktop/VARA.desktop ~/Desktop/VARA\ Chat.desktop ~/Desktop/VARA\ FM.desktop ~/Desktop/Winlink\ Express.desktop 2>/dev/null # remove old winlink/wine desktop shortcuts (in case we are reinstalling wine)
+            
+            # Greet the user
             run_greeting
-        
-        ### Install Wine & winetricks
+            if [ "$ARG" = "bap" ]; then
+                sleep 10 # If using Build-a-Pi (if 'bap' was passed to the script) then let greeting run without user intervention.
+		echo "Install will begin in 10 seconds"
+            else
+                read -n 1 -s -r -p "Press any key to continue . . ."
+            fi
+            clear
+            
+        ### Install Wine, winetricks, autohotkey, and box86
             run_installwine "pi4" "devel" "7.1" "debian" "${VERSION_CODENAME}" "-1" # windows API-call interperter for non-windows OS's - freeze version to ensure compatability
             run_installwinetricks # software installer script for wine
+            run_installahk
             run_downloadbox86 10_Dec_21 # emulator to run wine-i386 on ARM - freeze version to ensure compatability
-            
+        
         ### Set up Wine (silently make & configure a new wineprefix)
             run_setupwineprefix $ARG # if 'vara_only' was passed to the winelink script, then pass 'vara_only' to this subroutine function too
-	    
+	
         ### Install Winlink & VARA into our configured wineprefix
-            if [ "$ARG" = "vara_only" ]; then
+            if [ "$ARG" = "vara_only" ] || [ "$ARG" = "bap" ]; then
                 run_installvara
             else
                 run_installrms
@@ -93,12 +109,21 @@ function run_main()
         
         ### Post-installation
             run_makewineserverkscript
-            run_makevaraupdatescript
+            run_makevarasoundcardsetupscript
+            if [ "$ARG" = "bap" ]; then
+                : # If 'bap' is passed to this script, then don't run run_varasoundcardsetup
+            else
+                run_varasoundcardsetup
+            fi
+	    run_makeuninstallscript
             clear
             echo -e "\n${GREENTXT}Setup complete.${NORMTXT}\n"
-            cd .. && rm -rf Winelink-tmp winelink.log # cleanup
-            
-        exit
+	    
+	    # cleanup
+	    rm -rf ${HOME}/winelink/downloads
+	    rm ${HOME}/winelink/winelink.log
+        cd ..
+    exit
 }
 
 
@@ -137,14 +162,16 @@ function run_downloadbox86()  # Download & install Box86. (This function needs a
     local date="$1"
     
     echo -e "\n${GREENTXT}Downloading and installing Box86 . . .${NORMTXT}\n"
-    mkdir box86; cd box86
-        sudo rm /usr/local/bin/box86 # in case box86 is already installed and running
-        wget -q https://archive.org/download/box86.7z_20200928/box86_"$date".7z || { echo "box86_$date download failed!" && run_giveup; }
-        7z x box86_"$date".7z
-        sudo cp box86_"$date"/build/system/box86.conf /etc/binfmt.d/
-        sudo cp box86_"$date"/build/box86 /usr/local/bin/box86
-        sudo cp box86_"$date"/x86lib/* /usr/lib/i386-linux-gnu/
-        sudo systemctl restart systemd-binfmt # must be run after first installation of box86 (initializes binfmt configs so any encountered i386 binaries are sent to box86)
+    mkdir downloads 2>/dev/null; cd downloads
+        mkdir box86; cd box86
+            sudo rm /usr/local/bin/box86 2>/dev/null # in case box86 is already installed and running
+            wget -q https://archive.org/download/box86.7z_20200928/box86_"$date".7z || { echo "box86_$date download failed! Please check your internet connection and re-run the script." && run_giveup; }
+            7z x box86_"$date".7z -y -bsp0 -bso0
+            sudo cp box86_"$date"/build/system/box86.conf /etc/binfmt.d/
+            sudo cp box86_"$date"/build/box86 /usr/local/bin/box86
+            sudo cp box86_"$date"/x86lib/* /usr/lib/i386-linux-gnu/
+            sudo systemctl restart systemd-binfmt # must be run after first installation of box86 (initializes binfmt configs so any encountered i386 binaries are sent to box86)
+        cd ..
     cd ..
 }
 
@@ -154,62 +181,29 @@ function run_buildbox86()  # Build & install Box86. (This function needs a commi
     local commit="$1"
     
     echo -e "\n${GREENTXT}Building and installing Box86 . . .${NORMTXT}\n"
-    mkdir box86; cd box86
-        rm -rf box86-builder; mkdir box86-builder && cd box86-builder/
-            git clone https://github.com/ptitSeb/box86 && cd box86/
-                git checkout "$commit"
-                mkdir build; cd build
-                    cmake .. -DRPI4=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-                    make #-j4 may cause crashes in some builds of box86 due to high cpu load
-                    sudo make install # copies box86 files into their directories (/usr/local/bin/box86, /usr/lib/i386-linux-gnu/, /etc/binfmt.d/)
+    mkdir downloads 2>/dev/null; cd downloads
+        mkdir box86; cd box86
+            rm -rf box86-builder; mkdir box86-builder && cd box86-builder/
+                git clone https://github.com/ptitSeb/box86 && cd box86/
+                    git checkout "$commit"
+                    mkdir build; cd build
+                        cmake .. -DRPI4=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+                        make #-j4 may cause crashes in some builds of box86 due to high cpu load
+                        sudo make install # copies box86 files into their directories (/usr/local/bin/box86, /usr/lib/i386-linux-gnu/, /etc/binfmt.d/)
+                        sudo systemctl restart systemd-binfmt # must be run after first installation of box86 (initializes binfmt configs so any encountered i386 binaries are sent to box86)
+                    cd ..
                 cd ..
             cd ..
         cd ..
     cd ..
-    sudo systemctl restart systemd-binfmt # must be run after first installation of box86 (initializes binfmt configs so any encountered i386 binaries are sent to box86)
 }
-
-function run_setupwineprefix()  # Set up a new wineprefix silently.  A wineprefix is kind of like a virtual harddrive for wine
-{
-    # Store first string passed to this function as a variable
-    local varaonly="$1"
-    
-    # Silently create a new wineprefix
-        echo -e "\n${GREENTXT}Creating a new wineprefix.  This may take a moment . . .${NORMTXT}\n" 
-        rm -rf ~/.cache/wine # make sure no old wine-mono files are in wine's cache, or else they will be auto-installed on first wineboot
-        DISPLAY=0 WINEARCH=win32 wine wineboot # initialize Wine silently (silently makes a fresh wineprefix in `~/.wine`)
-
-    # Install pre-requisite software into the wineprefix for RMS Express and VARA
-        if [ "$varaonly" = "vara_only" ]; then
-	    echo -e "\n${GREENTXT}Setting up your wineprefix for VARA . . .${NORMTXT}\n"
-	    BOX86_NOBANNER=1 winetricks -q vb6run pdh_nt4 win7 sound=alsa # for VARA
-	else
-	    echo -e "\n${GREENTXT}Setting up your wineprefix for RMS Express & VARA . . .${NORMTXT}\n"
-	    run_installwinemono # for RMS Express - wine-mono replaces dotnet46
-	    #BOX86_NOBANNER=1 winetricks -q dotnet46 win7 sound=alsa # for RMS Express
-	    BOX86_NOBANNER=1 winetricks -q vb6run pdh_nt4 win7 sound=alsa # for VARA
-	fi
-	# TODO: Check to see if 'winetricks -q corefonts riched20' would make text look nicer
-
-    # Guide the user to the wineconfig audio menu (configure hardware soundcard input/output)
-        sudo apt-get install zenity -y
-        clear
-        echo ""
-        echo -e "\n${GREENTXT}In winecfg, go to the Audio tab to set up your system's in/out soundcards.\n(please click 'Ok' on the user prompt textbox to continue)${NORMTXT}"
-        zenity --info --height 100 --width 350 --text="We will now setup your soundcards for Wine. \n\nPlease navigate to the Audio tab and choose your systems soundcards \n\nInstall will continue once you have closed the winecfg menu." --title="Wine Soundcard Setup"
-        echo -e "${GREENTXT}Loading winecfg now . . .${NORMTXT}\n"
-        echo ""
-        BOX86_NOBANNER=1 winecfg # nobanner just for prettier terminal
-        clear
-}
-
 function run_installwinemono()  # Wine-mono replaces MS.NET 4.6 and earlier.
 {
     # MS.NET 4.6 takes a very long time to install on RPi4 in Wine and runs slower than wine-mono
     sudo apt-get install p7zip-full -y
     mkdir ~/.cache/wine 2>/dev/null
     echo -e "\n${GREENTXT}Downloading and installing wine-mono . . .${NORMTXT}\n"
-    wget -q -P ~/.cache/wine https://github.com/madewokherd/wine-mono/releases/download/wine-mono-7.1.3/wine-mono-7.1.3-x86.msi || { echo "wine-mono .msi install file download failed!" && run_giveup; }
+    wget -q -P ~/.cache/wine https://github.com/madewokherd/wine-mono/releases/download/wine-mono-7.1.3/wine-mono-7.1.3-x86.msi || { echo "wine-mono .msi install file download failed! Please check your internet connection and try again." && run_giveup; }
     wine msiexec /i ~/.cache/wine/wine-mono-7.1.3-x86.msi
     rm -rf ~/.cache/wine # clean up to save disk space
 }
@@ -240,8 +234,8 @@ function run_installwine()  # Download and install Wine for i386 Debian Buster (
 
         # Download, extract, and install wine-i386 onto our armhf device
             echo -e "\n${GREENTXT}Downloading wine . . .${NORMTXT}"
-            wget -q https://dl.winehq.org/wine-builds/debian/dists/${dist}/main/binary-i386/wine-${branch}-i386_${version}~${dist}${tag}_i386.deb || { echo "wine-${branch}-i386_${version}_i386.deb download failed!" && run_giveup; }
-            wget -q https://dl.winehq.org/wine-builds/debian/dists/${dist}/main/binary-i386/wine-${branch}_${version}~${dist}${tag}_i386.deb || { echo "wine-${branch}_${version}_i386.deb download failed!" && run_giveup; }
+            wget -q https://dl.winehq.org/wine-builds/debian/dists/${dist}/main/binary-i386/wine-${branch}-i386_${version}~${dist}${tag}_i386.deb || { echo "wine-${branch}-i386_${version}_i386.deb download failed! Please check your internet connection and re-run the script." && run_giveup; }
+            wget -q https://dl.winehq.org/wine-builds/debian/dists/${dist}/main/binary-i386/wine-${branch}_${version}~${dist}${tag}_i386.deb || { echo "wine-${branch}_${version}_i386.deb download failed! Please check your internet connection and re-run the script." && run_giveup; }
             echo -e "${GREENTXT}Extracting wine . . .${NORMTXT}"
             dpkg-deb -x wine-${branch}-i386_${version}~${dist}${tag}_i386.deb wine-installer
             dpkg-deb -x wine-${branch}_${version}~${dist}${tag}_i386.deb wine-installer
@@ -265,9 +259,46 @@ function run_installwinetricks() # Download and install winetricks
     mkdir downloads 2>/dev/null; cd downloads
         echo -e "\n${GREENTXT}Downloading and installing winetricks . . .${NORMTXT}\n"
         sudo mv /usr/local/bin/winetricks /usr/local/bin/winetricks-old 2>/dev/null # backup any old winetricks installs
-        wget -q https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks || { echo "winetricks download failed!" && run_giveup; } # download
+        wget -q https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks || { echo "winetricks download failed! Please check your internet connection and re-run the script." && run_giveup; } # download
         sudo chmod +x winetricks
         sudo mv winetricks /usr/local/bin # install
+    cd ..
+}
+
+function run_setupwineprefix()  # Set up a new wineprefix silently.  A wineprefix is kind of like a virtual harddrive for wine
+{
+    # Store first string passed to this function as a variable
+    local varaonly="$1"
+    
+    # Silently create a new wineprefix
+        echo -e "\n${GREENTXT}Creating a new wineprefix.  This may take a moment . . .${NORMTXT}\n" 
+        rm -rf ~/.cache/wine # make sure no old wine-mono files are in wine's cache, or else they will be auto-installed on first wineboot
+        DISPLAY=0 WINEARCH=win32 wine wineboot # initialize Wine silently (silently makes a fresh wineprefix in `~/.wine`)
+
+    # Install pre-requisite software into the wineprefix for RMS Express and VARA
+        if [ "$varaonly" = "vara_only" ]; then
+	    echo -e "\n${GREENTXT}Setting up your wineprefix for VARA . . .${NORMTXT}\n"
+	    BOX86_NOBANNER=1 winetricks -q vb6run pdh_nt4 win7 sound=alsa # for VARA
+	else
+	    echo -e "\n${GREENTXT}Setting up your wineprefix for RMS Express & VARA . . .${NORMTXT}\n"
+	    run_installwinemono # for RMS Express - wine-mono replaces dotnet46
+	    #BOX86_NOBANNER=1 winetricks -q dotnet46 win7 sound=alsa # for RMS Express
+	    BOX86_NOBANNER=1 winetricks -q vb6run pdh_nt4 win7 sound=alsa # for VARA
+	fi
+	# TODO: Check to see if 'winetricks -q corefonts riched20' would make text look nicer
+}
+
+function run_installahk()
+{
+    mkdir downloads 2>/dev/null; cd downloads
+        # Download AutoHotKey
+	echo -e "\n${GREENTXT}Downloading AutoHotkey . . .${NORMTXT}\n"
+        wget -q https://github.com/AutoHotkey/AutoHotkey/releases/download/v1.0.48.05/AutoHotkey104805_Install.exe || { echo "AutoHotkey download failed! Please check your internet connection and re-run the script." && run_giveup; }
+        7z x AutoHotkey104805_Install.exe AutoHotkey.exe -y -bsp0 -bso0
+	mkdir ${HOME}/winelink 2>/dev/null
+	mkdir ${AHK}
+	sudo mv AutoHotkey.exe ${AHK}/AutoHotkey.exe
+	sudo chmod +x ${AHK}/AutoHotkey.exe
     cd ..
 }
 
@@ -276,7 +307,7 @@ function run_installrms()  # Download/extract/install RMS Express
     mkdir downloads 2>/dev/null; cd downloads
         # Download RMS Express (no matter its version number) [https://downloads.winlink.org/User%20Programs/]
             echo -e "\n${GREENTXT}Downloading and installing RMS Express . . .${NORMTXT}\n"
-            wget -q -r -l1 -np -nd -A "Winlink_Express_install_*.zip" https://downloads.winlink.org/User%20Programs || { echo "RMS Express download failed!" && run_giveup; }
+            wget -q -r -l1 -np -nd -A "Winlink_Express_install_*.zip" https://downloads.winlink.org/User%20Programs || { echo "RMS Express download failed! Please check your internet connection and re-run the script." && run_giveup; }
         
         # We could also use curl if we don't want to use wget to find the link . . .
             #RMSLINKPREFIX="https://downloads.winlink.org"
@@ -285,366 +316,398 @@ function run_installrms()  # Download/extract/install RMS Express
             #wget -q $RMSLINK || { echo "RMS Express download failed!" && run_giveup; }
 
         # Extract/install RMS Express
-            7z x Winlink_Express_install_*.zip -o"WinlinkExpressInstaller"
+            7z x Winlink_Express_install_*.zip -o"WinlinkExpressInstaller" -y -bsp0 -bso0
             wine WinlinkExpressInstaller/Winlink_Express_install.exe /SILENT
+	    
+	# Clean up
+            rm -rf WinlinkExpressInstaller
+	    sleep 3; sudo rm -rf ~/.local/share/applications/wine/Programs/RMS\ Express/ # Remove wine's auto-generated program icon from the start menu
             
         # Make a RMS Express desktop shortcut
-            echo '[Desktop Entry]'                                                                             >> ~/Desktop/Winlink\ Express.desktop
-            echo 'Name=Winlink Express'                                                                        >> ~/Desktop/Winlink\ Express.desktop
-            echo 'Exec=env BOX86_DYNAREC_BIGBLOCK=0 wine '$HOME'/.wine/drive_c/RMS\ Express/RMS\ Express.exe'  >> ~/Desktop/Winlink\ Express.desktop
-            #echo 'Exec=env BOX86_DYNAREC_BIGBLOCK=0 BOX86_DYNAREC_STRONGMEM=1 wine '$HOME'/.wine/drive_c/RMS\ Express/RMS\ Express.exe'  >> ~/Desktop/Winlink\ Express.desktop # TODO: Does this improve stability or cost speed?
-            echo 'Type=Application'                                                                            >> ~/Desktop/Winlink\ Express.desktop
-            echo 'StartupNotify=true'                                                                          >> ~/Desktop/Winlink\ Express.desktop
-            echo 'Icon=219D_RMS Express.0'                                                                     >> ~/Desktop/Winlink\ Express.desktop
-            echo 'StartupWMClass=rms express.exe'                                                              >> ~/Desktop/Winlink\ Express.desktop
-            #cp ~/.local/share/applications/wine/Programs/RMS\ Express/Winlink\ Express.desktop ~/Desktop/ # sometimes wine makes broken links
-            sudo chmod +x ~/Desktop/Winlink\ Express.desktop
+            echo '[Desktop Entry]'                                                                             | sudo tee ${STARTMENU}/winlinkexpress.desktop > /dev/null
+            echo 'Name=Winlink Express'                                                                        | sudo tee -a ${STARTMENU}/winlinkexpress.desktop > /dev/null
+            echo 'GenericName=Winlink Express'                                                                 | sudo tee -a ${STARTMENU}/winlinkexpress.desktop > /dev/null
+            echo 'Comment=RMS Express emulated with Box86/Wine'                                                | sudo tee -a ${STARTMENU}/winlinkexpress.desktop > /dev/null
+            echo 'Exec=env BOX86_DYNAREC_BIGBLOCK=0 WINEDEBUG=-all wine '$HOME'/.wine/drive_c/RMS\ Express/RMS\ Express.exe'  | sudo tee -a ${STARTMENU}/winlinkexpress.desktop > /dev/null
+            #echo 'Exec=env BOX86_DYNAREC_BIGBLOCK=0 BOX86_DYNAREC_STRONGMEM=1 WINEDEBUG=-all wine '$HOME'/.wine/drive_c/RMS\ Express/RMS\ Express.exe'  | sudo tee -a ${STARTMENU}/winlinkexpress.desktop > /dev/null # TODO: Does this improve stability or cost speed?
+            echo 'Type=Application'                                                                            | sudo tee -a ${STARTMENU}/winlinkexpress.desktop > /dev/null
+            echo 'StartupNotify=true'                                                                          | sudo tee -a ${STARTMENU}/winlinkexpress.desktop > /dev/null
+            echo 'Icon=219D_RMS Express.0'                                                                     | sudo tee -a ${STARTMENU}/winlinkexpress.desktop > /dev/null
+            echo 'StartupWMClass=rms express.exe'                                                              | sudo tee -a ${STARTMENU}/winlinkexpress.desktop > /dev/null
+            echo 'Categories=HamRadio;'                                                                        | sudo tee -a ${STARTMENU}/winlinkexpress.desktop > /dev/null
     cd ..
 }
 
-function run_installvara()  # Download / extract / install VARA HF/FM/Chat, then configure them with AutoHotKey scripts
+function run_installvara()  # Download / extract / install VARA HF/FM/Chat
 {
     sudo apt-get install curl megatools p7zip-full -y
     
-    mkdir downloads 2>/dev/null; cd downloads
-        # Download / extract VARA HF
-            # files: VARA HF v4.4.3 Setup > VARA setup (Run as Administrator).exe > /SILENT install has an OK button at end
-            echo -e "\n${GREENTXT}Downloading VARA HF . . .${NORMTXT}\n"
-            VARAHFLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA HF v)') # Find the mega.nz link from the rosmodem website no matter its version, then store it as a variable
-            megadl ${VARAHFLINK} || { echo "VARA HF download failed!" && run_giveup; }
-            7z x VARA\ HF*.zip -o"VARAHFInstaller"
-            cp VARAHFInstaller/VARA\ setup*.exe ~/.wine/drive_c/ # move VARA installer here (so AHK can find it later)
-            # VARA HF will be installed and configured with an AHK script later
+    # Make the VARA Update script, then run it in silent mode (to install VARA Suite)
+        run_makevaraupdatescript
+        bash "${HOME}/winelink/Update VARA" silent
         
-        # Download / extract VARA FM
-            # files: VARA FM v4.1.3 Setup.zip > VARA FM setup (Run as Administrator).exe > /SILENT install has an OK button at end
-            echo -e "\n${GREENTXT}Downloading VARA FM . . .${NORMTXT}\n"
-            VARAFMLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA FM v)') # Find the mega.nz link from the rosmodem website no matter its version, then store it as a variable
-            megadl ${VARAFMLINK} || { echo "VARA FM download failed!" && run_giveup; }
-            7z x VARA\ FM*.zip -o"VARAFMInstaller"
-            cp VARAFMInstaller/VARA\ FM\ setup*.exe ~/.wine/drive_c/ # move VARA installer here (so AHK can find it later)
-            # VARA FM will be installed and configured with an AHK script later
-            
-        # Download / extract / install VARA Chat
-            # files: VARA Chat v1.2.5 Setup.zip > VARA Chat setup (Run as Administrator).exe > /SILENT install is silent
-            echo -e "\n${GREENTXT}Downloading VARA Chat . . .${NORMTXT}\n"
-            VARACHATLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA Chat v)') # Find the mega.nz link from the rosmodem website no matter its version, then store it as a variable
-            megadl ${VARACHATLINK} || { echo "VARA Chat download failed!" && run_giveup; }
-            7z x VARA\ Chat*.zip -o"VARAChatInstaller"
-            
-            echo -e "\n${GREENTXT}Installing VARA Chat . . .${NORMTXT}\n"
-            wine VARAChatInstaller/VARA\ Chat\ setup*.exe /SILENT # install VARA Chat
-            
-        # TODO: Add VARA SAT
-            
-            # Make a VARA Chat desktop shortcut
-            echo '[Desktop Entry]'                                                                                            >> ~/Desktop/VARA\ Chat.desktop
-            echo 'Name=VARA Chat'                                                                                             >> ~/Desktop/VARA\ Chat.desktop
-            echo 'Exec=wine '$HOME'/.wine/drive_c/VARA/VARA\ Chat.exe'                                                        >> ~/Desktop/VARA\ Chat.desktop
-            echo 'Type=Application'                                                                                           >> ~/Desktop/VARA\ Chat.desktop
-            echo 'StartupNotify=true'                                                                                         >> ~/Desktop/VARA\ Chat.desktop
-            echo 'Icon=DF53_VARA Chat.0'                                                                                      >> ~/Desktop/VARA\ Chat.desktop
-            echo 'StartupWMClass=vara chat.exe'                                                                               >> ~/Desktop/VARA\ Chat.desktop
-            #cp ~/.local/share/applications/wine/Programs/VARA\ Chat/VARA.desktop ~/Desktop/VARA\ Chat.desktop # wine makes broken shortcuts sometimes
-            sudo chmod +x ~/Desktop/VARA\ Chat.desktop
-    cd ..
-        
-    mkdir ahk; cd ahk
-        # Download AutoHotKey
-            wget -q https://github.com/AutoHotkey/AutoHotkey/releases/download/v1.0.48.05/AutoHotkey104805_Install.exe || { echo "AutoHotKey download failed!" && run_giveup; }
-            7z x AutoHotkey104805_Install.exe AutoHotkey.exe
-            sudo chmod +x AutoHotkey.exe
-        
-        # Install VARA HF silently
-            # Create varahf_install.ahk
-            # The VARA installer prompts the user to hit 'OK' even during silent install (due to a secondary installer).  We will suppress this prompt with AHK.
-            echo '; AHK script to make VARA installer run completely silent'                       >> varahf_install.ahk
-            echo 'SetTitleMatchMode, 2'                                                            >> varahf_install.ahk
-            echo 'SetTitleMatchMode, slow'                                                         >> varahf_install.ahk
-            echo '        Run, VARA setup (Run as Administrator).exe /SILENT, C:\'                 >> varahf_install.ahk
-            echo '        WinWait, VARA Setup ; Wait for the "VARA installed successfully" window' >> varahf_install.ahk
-            echo '        ControlClick, Button1, VARA Setup ; Click the OK button'                 >> varahf_install.ahk
-            echo '        WinWaitClose'                                                            >> varahf_install.ahk
-
-            # Run varahf_install.ahk
-            echo -e "\n${GREENTXT}Installing VARA HF . . .${NORMTXT}\n"
-            BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine AutoHotkey.exe varahf_install.ahk # install VARA silently using AHK
-            rm ~/.wine/drive_c/VARA\ setup*.exe # clean up
-            
-            # Make a VARA HF desktop shortcut
-            echo '[Desktop Entry]'                                                                 >> ~/Desktop/VARA.desktop
-            echo 'Name=VARA'                                                                       >> ~/Desktop/VARA.desktop
-            echo 'Exec=wine '$HOME'/.wine/drive_c/VARA/VARA.exe'                                   >> ~/Desktop/VARA.desktop
-            echo 'Type=Application'                                                                >> ~/Desktop/VARA.desktop
-            echo 'StartupNotify=true'                                                              >> ~/Desktop/VARA.desktop
-            echo 'Icon=F302_VARA.0'                                                                >> ~/Desktop/VARA.desktop
-            echo 'StartupWMClass=vara.exe'                                                         >> ~/Desktop/VARA.desktop
-            #cp ~/.local/share/applications/wine/Programs/VARA/VARA.desktop ~/Desktop/ # wine makes broken shortcuts sometimes
-            sudo chmod +x ~/Desktop/VARA.desktop
-        
-        # Install VARA FM silently
-            # Create/run varafm_install.ahk
-            # The VARA installer prompts the user to hit 'OK' even during silent install (due to a secondary installer).  We will suppress this prompt with AHK.
-            echo '; AHK script to make VARA installer run completely silent'                       >> varafm_install.ahk
-            echo 'SetTitleMatchMode, 2'                                                            >> varafm_install.ahk
-            echo 'SetTitleMatchMode, slow'                                                         >> varafm_install.ahk
-            echo '        Run, VARA FM setup (Run as Administrator).exe /SILENT, C:\'              >> varafm_install.ahk
-            echo '        WinWait, VARA Setup ; Wait for the "VARA installed successfully" window' >> varafm_install.ahk
-            echo '        ControlClick, Button1, VARA Setup ; Click the OK button'                 >> varafm_install.ahk
-            echo '        WinWaitClose'                                                            >> varafm_install.ahk
-            
-            # Run varafm_install.ahk
-            echo -e "\n${GREENTXT}Installing VARA FM . . .${NORMTXT}\n"
-            BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine AutoHotkey.exe varafm_install.ahk # install VARA silently using AHK
-            rm ~/.wine/drive_c/VARA\ FM\ setup*.exe # clean up
-            
-            # Make a VARA FM desktop shortcut
-            echo '[Desktop Entry]'                                                                 >> ~/Desktop/VARA\ FM.desktop
-            echo 'Name=VARA FM'                                                                    >> ~/Desktop/VARA\ FM.desktop
-            echo 'Exec=wine '$HOME'/.wine/drive_c/VARA\ FM/VARAFM.exe'                             >> ~/Desktop/VARA\ FM.desktop
-            echo 'Type=Application'                                                                >> ~/Desktop/VARA\ FM.desktop
-            echo 'StartupNotify=true'                                                              >> ~/Desktop/VARA\ FM.desktop
-            echo 'Icon=C497_VARAFM.0'                                                              >> ~/Desktop/VARA\ FM.desktop
-            echo 'StartupWMClass=varafm.exe'                                                       >> ~/Desktop/VARA\ FM.desktop
-            #cp ~/.local/share/applications/wine/Programs/VARA\ FM/VARA\ FM.desktop ~/Desktop/ # wine makes broken shortcuts sometimes
-            sudo chmod +x ~/Desktop/VARA\ FM.desktop
-        
-        # Guide the user to the VARA HF audio setup menu (configure hardware soundcard input/output)
-            echo -e "\n${GREENTXT}Configuring VARA HF . . .${NORMTXT}\n"
-            sudo apt-get install zenity -y
-            clear
-            echo -e "\n${GREENTXT}Please set up your soundcard input/output for VARA HF\n(please click 'Ok' on the user prompt textbox to continue)${NORMTXT}\n"
-            zenity --info --height 100 --width 350 --text="We will now setup your soundcards for VARA HF. \n\nInstall will continue once you have closed the VARA Settings menu." --title="VARA HF Soundcard Setup"
-            echo -e "\n${GREENTXT}Loading VARA HF now . . .${NORMTXT}\n"
-
-            # Create/run varahf_configure.ahk
-            # We will disable all graphics except gauges to help RPi4 CPU. Users can enable these if they have better CPU
-            # We will then open the soundcard menu for users so that they can set up their sound cards
-            # After the settings menu is closed, we will close VARA HF
-            echo '; AHK script to assist users in setting up VARA on its first run'                >> varahf_configure.ahk
-            echo 'SetTitleMatchMode, 2'                                                            >> varahf_configure.ahk
-            echo 'SetTitleMatchMode, slow'                                                         >> varahf_configure.ahk
-            echo '        Run, VARA.exe, C:\VARA'                                                  >> varahf_configure.ahk
-            echo '        WinActivate, VARA HF'                                                    >> varahf_configure.ahk
-            echo '        WinWait, VARA HF ; Wait for VARA HF to open'                             >> varahf_configure.ahk
-            echo '        Sleep 2500 ; If we dont wait at least 2000 for VARA then AHK wont work'  >> varahf_configure.ahk
-            echo '        Send, !{s} ; Open SoundCard menu for user to set up sound cards'         >> varahf_configure.ahk
-            echo '        Sleep 500'                                                               >> varahf_configure.ahk
-            echo '        Send, {Down}'                                                            >> varahf_configure.ahk
-            echo '        Sleep, 100'                                                              >> varahf_configure.ahk
-            echo '        Send, {Enter}'                                                           >> varahf_configure.ahk
-            echo '        Sleep 5000'                                                              >> varahf_configure.ahk
-            echo '        WinWaitClose, SoundCard ; Wait for user to finish setting up soundcard'  >> varahf_configure.ahk
-            echo '        Sleep 100'                                                               >> varahf_configure.ahk
-            echo '        WinClose, VARA HF ; Close VARA'                                          >> varahf_configure.ahk
-            BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine AutoHotkey.exe varahf_configure.ahk # nobanner option to make console prettier
-            sleep 5
-            sed -i 's+View\=1+View\=3+g' ~/.wine/drive_c/VARA/VARA.ini # turn off VARA HF's waterfall (change 'View=1' to 'View=3' in VARA.ini). INI file shows up after first run of VARA HF.
-        
-        # Guide the user to the VARA FM audio setup menu (configure hardware soundcard input/output)
-            sudo apt-get install zenity -y
-            clear
-            echo -e "\n${GREENTXT}Please set up your soundcard input/output for VARA FM\n(please click 'Ok' on the user prompt textbox to continue)${NORMTXT}\n"
-            zenity --info --height 100 --width 350 --text="We will now setup your soundcards for VARA FM. \n\nInstall will continue once you have closed the VARA Settings menu." --title="VARA FM Soundcard Setup"
-            echo -e "\n${GREENTXT}Loading VARA FM now . . .${NORMTXT}\n"
-
-            #Create varafm_configure.ahk
-            # We will disable all graphics except gauges to help RPi4 CPU. Users can enable these if they have better CPU
-            # We will then open the soundcard menu for users so that they can set up their sound cards
-            # After the settings menu is closed, we will close VARA FM
-            echo '; AHK script to assist users in setting up VARA on its first run'                >> varafm_configure.ahk
-            echo 'SetTitleMatchMode, 2'                                                            >> varafm_configure.ahk
-            echo 'SetTitleMatchMode, slow'                                                         >> varafm_configure.ahk
-            echo '        Run, VARAFM.exe, C:\VARA FM'                                             >> varafm_configure.ahk
-            echo '        WinActivate, VARA FM'                                                    >> varafm_configure.ahk
-            echo '        WinWait, VARA FM ; Wait for VARA FM to open'                             >> varafm_configure.ahk
-            echo '        Sleep 2000 ; If we dont wait at least 2000 for VARA then AHK wont work'  >> varafm_configure.ahk
-            echo '        Send, !{s} ; Open SoundCard menu for user to set up sound cards'         >> varafm_configure.ahk
-            echo '        Sleep 500'                                                               >> varafm_configure.ahk
-            echo '        Send, {Down}'                                                            >> varafm_configure.ahk
-            echo '        Sleep, 100'                                                              >> varafm_configure.ahk
-            echo '        Send, {Enter}'                                                           >> varafm_configure.ahk
-            echo '        Sleep 5000'                                                              >> varafm_configure.ahk
-            echo '        WinWaitClose, SoundCard ; Wait for user to finish setting up soundcard'  >> varafm_configure.ahk
-            echo '        Sleep 100'                                                               >> varafm_configure.ahk
-            echo '        WinClose, VARA FM ; Close VARA'                                          >> varafm_configure.ahk
-            BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine AutoHotkey.exe varafm_configure.ahk # Nobanner option to make console prettier
-            sleep 5
-            sed -i 's+View\=1+View\=3+g' ~/.wine/drive_c/VARA\ FM/VARAFM.ini # turn off VARA FM's graphics (change 'View=1' to 'View=3' in VARAFM.ini). INI file shows up after first run of VARA FM.
-    cd ..
-    
     # In older versions of wine, this fixed graphics glitches caused by Wine's (winecfg) window manager (VARA appeared as a black screen when auto-run by RMS Express)
         # NOTE: If using dotnet (instead of wine-mono) on Pi, this will slow things down a lot
         # Create override-x11.reg
-        echo 'REGEDIT4'                                      >> override-x11.reg
-        echo ''                                              >> override-x11.reg
-        echo '[HKEY_CURRENT_USER\Software\Wine\X11 Driver]'  >> override-x11.reg
-        echo '"Decorated"="Y"'                               >> override-x11.reg
-        echo '"Managed"="N"'                                 >> override-x11.reg
+        echo 'REGEDIT4'                                        > ${HOME}/winelink/override-x11.reg
+        echo ''                                                >> ${HOME}/winelink/override-x11.reg
+        echo '[HKEY_CURRENT_USER\Software\Wine\X11 Driver]'    >> ${HOME}/winelink/override-x11.reg
+        echo '"Decorated"="Y"'                                 >> ${HOME}/winelink/override-x11.reg
+        echo '"Managed"="N"'                                   >> ${HOME}/winelink/override-x11.reg
         wine cmd /c regedit /s override-x11.reg
-    
+	rm ${HOME}/winelink/override-x11.reg
+
     # Install dll's needed by users of "RA-boards," like the DRA-50
     #  https://masterscommunications.com/products/radio-adapter/dra/dra-index.html
-        sudo apt-get install p7zip-full -y
-        BOX86_NOBANNER=1 winetricks -q hid
-        wget http://uz7.ho.ua/modem_beta/ptt-dll.zip
-        7z x ptt-dll.zip -o"$HOME/.wine/drive_c/VARA/" # For VARA HF & VARAChat
-        7z x ptt-dll.zip -o"$HOME/.wine/drive_c/VARA FM/" # For VARA FM
-        
+       #BOX86_NOBANNER=1 winetricks -q hid # unsure if this is needed...
+       ##sudo apt-get install p7zip-full -y
+       ##wget http://uz7.ho.ua/modem_beta/ptt-dll.zip
+       ##7z x ptt-dll.zip -o"$HOME/.wine/drive_c/VARA/" -y -bsp0 -bso0 # For VARA HF & VARAChat
+       ##7z x ptt-dll.zip -o"$HOME/.wine/drive_c/VARA FM/" -y -bsp0 -bso0 # For VARA FM
 }
 
-function run_installvARIM()  # Download, build, and install an open-source stand-alone interface for VARA, called vARIM
+function run_makevaraupdatescript()
 {
-    # Build and install vARIM for RPi - Building takes longer than downloading, but building is a cleaner install than the pre-compiled package
-    echo -e "\n${GREENTXT}Downloading and installing vARIM . . .${NORMTXT}\n"
-    sudo apt-get install gcc cmake zlibc libfltk1.3-dev libfltk-images1.3 -y # build dependencies
-    wget -q https://www.whitemesa.net/varim/src/varim-1.4.tar.gz || { echo "vARIM Sourcecode download failed!" && run_giveup; } # "Current vARIM Version 1.4 source code and help file"
-    tar -xzvf varim-1.4.tar.gz
-    cd varim-1.4
-            ./configure
-            make -j$(nproc)
-            sudo make install
-            sudo chmod 644 ~/varim/varim.ini
-    cd ..
-    rm -rf varim-1.4
-    cp /usr/local/share/applications/varim.desktop ~/Desktop/varim.desktop
-    sudo chmod +x ~/Desktop/varim.desktop
+	# Create 'Update\ VARA.sh'
 
-    ## Download and install vARIM for RPi3B+ or RPi4B
-    # THIS IS BROKEN - vARIM pre-made packages are 'portable' and thus can't be installed into /usr/local/bin like the compiled version.
-    #wget -q https://www.whitemesa.net/varim/pkg/varim-1.4-bin-linux-gnueabihf-armv7l.tar.gz || { echo "vARIM Portable download failed!" && run_giveup; }
-    #sudo apt-get install libfltk-images1.3 -y
-    #tar -xzvf varim-1.4-bin-linux-gnueabihf-armv7l.tar.gz
-    #cd varim-1.4
-    #        # Install components (based on how the install script for built versions of vARIM does it)
-    #        sudo mkdir -p '/usr/local/bin'
-    #        sudo mkdir -p '/usr/local/share/applications'
-    #        sudo mkdir -p '/usr/local/share/doc/varim'
-    #        sudo mkdir -p '/usr/local/share/varim'
-    #        sudo mkdir -p '/usr/local/share/pixmaps'
-    #        sudo install -c varim '/usr/local/bin'
-    #        sudo install -c -m 644 varim.desktop '/usr/local/share/applications'
-    #        sudo install -c -m 644 doc/varim-help-v1.4.pdf doc/varim-help.txt doc/varim\(1\)-v1.4.pdf doc/varim\(5\)-v1.4.pdf doc/NEWS doc/AUTHORS doc/COPYING doc/README '/usr/local/share/doc/varim'
-    #        sudo install -c -m 644 files/test.txt varim.ini in.mbox varim.png varim-64x64.png '/usr/local/share/varim'
-    #        sudo install -c -m 644 out.mbox sent.mbox '/usr/local/share/varim'
-    #        sudo install -c -m 644 varim.xpm '/usr/local/share/pixmaps'
-    #        cp /usr/local/share/applications/varim.desktop ~/Desktop/varim.desktop
-    #        sudo chmod +x ~/Desktop/varim.desktop
-    #cd ..
+	# Inject code into a new script that can be run later from the desktop by users who wish to update VARA HF, VARA FM, and VARAChat
+	#   Note that this script uses tabs (	) instead of spaces ( ) for formatting since it relies on heredoc (i.e. eom & eot).
+	#   Also note that none of this code gets run right now.
+	cat > ${HOME}/winelink/Update\ VARA <<- 'EOM'
+		#!/bin/bash
+		
+		export WINEDEBUG=-all # silence winedbg for this instance of the terminal
+		sudo apt-get install zenity curl megatools p7zip-full -y
+		SILENT="$1"
+		
+		# Create directories (in case they don't already exist)
+			mkdir ${HOME}/winelink 2>/dev/null
+			mkdir ${HOME}/winelink/ahk 2>/dev/null
+			mkdir ${HOME}/winelink/varaupdatefiles 2>/dev/null
+		# Set optional text colors
+			GREENTXT='\e[32m' # Green
+			NORMTXT='\e[0m' # Normal
+		# Set location variables
+			AHK="${HOME}/winelink/ahk"
+			VARAUPDATE="${HOME}/winelink/varaupdatefiles"
+			STARTMENU="/usr/share/applications" # Program shortcuts/icons can go here
+		
+		sudo rm -rf $VARAUPDATE 2>/dev/null # remove any failed vara update attempts
+		mkdir $VARAUPDATE
+		
+		if [ "$SILENT" != "silent" ]; then
+			# Ask user if they would like to update the VARA Suite
+			zenity --question --height 150 --width 500 --text="Would you like to update VARA HF, VARA FM, and VARA Chat?\\n\\n(RMS Express already checks for updates on its own)" --title="Update VARA Suite?"
+			ZENRESULT=$? # the answer of the yes/no questions is stored in the $? variable ( 0 = yes, 1 = no ).
+		else
+			: # If 'silent' was passed to the 'Update VARA' script, then continue without asking the user any questions
+		fi
+		
+		# Run VARA Suite update if user responded with 'yes', or if the user runs this script with 'silent' passed to it
+		if	[ "$ZENRESULT" = 0 ] || [ "$SILENT" = "silent" ]; # If user answered 'yes' or if 'silent' was passed to the 'Update VARA' script, then ...
+		then
+			if [ "$SILENT" != "silent" ]; then
+				zenity --warning --timeout=12 --height 150 --width 500 --text="Updating VARA HF, VARA FM, and VARA Chat now ...\\n\\nThis may take a moment." --title="Updating VARA Suite" &
+			fi
+			
+			# Download / extract / silently install VARA HF
+				# Search the rosmodem website for a VARA HF mega.nz link of any version, then download it
+					echo -e "\n${GREENTXT}Downloading VARA HF . . .${NORMTXT}\n"
+					VARAHFLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA HF v)')
+					megadl ${VARAHFLINK} --path=${VARAUPDATE} || { echo "VARA HF download failed! Please check your internet connection and re-run the script." && run_giveup; }
+					7z x ${VARAUPDATE}/VARA\ HF*.zip -o"${VARAUPDATE}/VARAHFInstaller" -y -bsp0 -bso0
+					mv ${VARAUPDATE}/VARAHFInstaller/VARA\ setup*.exe ~/.wine/drive_c/ # move VARA installer into wineprefix (so AHK can find it)
+
+				# Create varahf_install.ahk autohotkey script
+					# The VARA installer prompts the user to hit 'OK' even during silent install (due to a secondary installer).  We will suppress this prompt with AHK.
+					echo '; AHK script to make VARA installer run completely silent'                       > ${AHK}/varahf_install.ahk
+					echo 'SetTitleMatchMode, 2'                                                            >> ${AHK}/varahf_install.ahk
+					echo 'SetTitleMatchMode, slow'                                                         >> ${AHK}/varahf_install.ahk
+					echo '        Run, VARA setup (Run as Administrator).exe /SILENT, C:\'                 >> ${AHK}/varahf_install.ahk
+					echo '        WinWait, VARA Setup ; Wait for the "VARA installed successfully" window' >> ${AHK}/varahf_install.ahk
+					echo '        ControlClick, Button1, VARA Setup ; Click the OK button'                 >> ${AHK}/varahf_install.ahk
+					echo '        WinWaitClose'                                                            >> ${AHK}/varahf_install.ahk
+					
+				# Run varahf_install.ahk
+					echo -e "\n${GREENTXT}Installing VARA HF . . .${NORMTXT}\n"
+					BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine ${AHK}/AutoHotkey.exe ${AHK}/varahf_install.ahk # install VARA silently using AHK
+				
+				# Clean up the installation
+					rm ~/.wine/drive_c/VARA\ setup*.exe
+					rm ${AHK}/varahf_install.ahk
+					sleep 3; sudo rm -rf ${HOME}/.local/share/applications/wine/Programs/VARA/ # Remove wine's auto-generated VARA HF program icon from the start menu
+
+				# Make a custom VARA HF desktop shortcut
+					echo '[Desktop Entry]'                                                                 | sudo tee ${STARTMENU}/vara.desktop > /dev/null
+					echo 'Name=VARA'                                                                       | sudo tee -a ${STARTMENU}/vara.desktop > /dev/null
+					echo 'GenericName=VARA'                                                                | sudo tee -a ${STARTMENU}/vara.desktop > /dev/null
+					echo 'Comment=VARA HF TNC emulated with Box86/Wine'                                    | sudo tee -a ${STARTMENU}/vara.desktop > /dev/null
+					echo 'Exec=env WINEDEBUG=-all wine '$HOME'/.wine/drive_c/VARA/VARA.exe'                | sudo tee -a ${STARTMENU}/vara.desktop > /dev/null
+					echo 'Type=Application'                                                                | sudo tee -a ${STARTMENU}/vara.desktop > /dev/null
+					echo 'StartupNotify=true'                                                              | sudo tee -a ${STARTMENU}/vara.desktop > /dev/null
+					echo 'Icon=F302_VARA.0'                                                                | sudo tee -a ${STARTMENU}/vara.desktop > /dev/null
+					echo 'StartupWMClass=vara.exe'                                                         | sudo tee -a ${STARTMENU}/vara.desktop > /dev/null
+					echo 'Categories=HamRadio'                                                             | sudo tee -a ${STARTMENU}/vara.desktop > /dev/null
+
+			# Download / extract / silently install VARA FM
+				# Search the rosmodem website for a VARA FM mega.nz link of any version, then download it
+					echo -e "\n${GREENTXT}Downloading VARA FM . . .${NORMTXT}\n"
+					VARAFMLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA FM v)') # Find the mega.nz link from the rosmodem website no matter its version, then store it as a variable
+					megadl ${VARAFMLINK} --path=${VARAUPDATE} || { echo "VARA FM download failed! Please check your internet connection and re-run the script." && run_giveup; }
+					7z x ${VARAUPDATE}/VARA\ FM*.zip -o"${VARAUPDATE}/VARAFMInstaller" -y -bsp0 -bso0
+					mv ${VARAUPDATE}/VARAFMInstaller/VARA\ FM\ setup*.exe ~/.wine/drive_c/ # move VARA installer here (so AHK can find it later)
+
+				# Create varafm_install.ahk autohotkey script
+					# The VARA installer prompts the user to hit 'OK' even during silent install (due to a secondary installer).  We will suppress this prompt with AHK.
+					echo '; AHK script to make VARA installer run completely silent'                       > ${AHK}/varafm_install.ahk
+					echo 'SetTitleMatchMode, 2'                                                            >> ${AHK}/varafm_install.ahk
+					echo 'SetTitleMatchMode, slow'                                                         >> ${AHK}/varafm_install.ahk
+					echo '        Run, VARA FM setup (Run as Administrator).exe /SILENT, C:\'              >> ${AHK}/varafm_install.ahk
+					echo '        WinWait, VARA Setup ; Wait for the "VARA installed successfully" window' >> ${AHK}/varafm_install.ahk
+					echo '        ControlClick, Button1, VARA Setup ; Click the OK button'                 >> ${AHK}/varafm_install.ahk
+					echo '        WinWaitClose'                                                            >> ${AHK}/varafm_install.ahk
+
+				# Run varafm_install.ahk
+					echo -e "\n${GREENTXT}Installing VARA FM . . .${NORMTXT}\n"
+					BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine ${AHK}/AutoHotkey.exe ${AHK}/varafm_install.ahk # install VARA silently using AHK
+
+				# Clean up the installation
+					rm ~/.wine/drive_c/VARA\ FM\ setup*.exe
+					rm ${AHK}/varafm_install.ahk
+					sleep 3; sudo rm -rf ${HOME}/.local/share/applications/wine/Programs/VARA\ FM/ # Remove wine's auto-generated VARA FM program icon from the start menu
+
+				# Make a VARA FM desktop shortcut
+					echo '[Desktop Entry]'                                                                 | sudo tee ${STARTMENU}/vara-fm.desktop > /dev/null
+					echo 'Name=VARA FM'                                                                    | sudo tee -a ${STARTMENU}/vara-fm.desktop > /dev/null
+					echo 'GenericName=VARA FM'                                                             | sudo tee -a ${STARTMENU}/vara-fm.desktop > /dev/null
+					echo 'Comment=VARA FM TNC emulated with Box86/Wine'                                    | sudo tee -a ${STARTMENU}/vara-fm.desktop > /dev/null
+					echo 'Exec=env WINEDEBUG=-all wine '$HOME'/.wine/drive_c/VARA\ FM/VARAFM.exe'          | sudo tee -a ${STARTMENU}/vara-fm.desktop > /dev/null
+					echo 'Type=Application'                                                                | sudo tee -a ${STARTMENU}/vara-fm.desktop > /dev/null
+					echo 'StartupNotify=true'                                                              | sudo tee -a ${STARTMENU}/vara-fm.desktop > /dev/null
+					echo 'Icon=C497_VARAFM.0'                                                              | sudo tee -a ${STARTMENU}/vara-fm.desktop > /dev/null
+					echo 'StartupWMClass=varafm.exe'                                                       | sudo tee -a ${STARTMENU}/vara-fm.desktop > /dev/null
+					echo 'Categories=HamRadio'                                                             | sudo tee -a ${STARTMENU}/vara-fm.desktop > /dev/null
+
+			# TODO: Add VARA SAT
+
+			# Download / extract / silently install VARA Chat
+				# Search the rosmodem website for a VARA Chat mega.nz link of any version, then download it
+					echo -e "\n${GREENTXT}Downloading VARA Chat . . .${NORMTXT}\n"
+					VARACHATLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA Chat v)') # Find the mega.nz link from the rosmodem website no matter its version, then store it as a variable
+					megadl ${VARACHATLINK} --path=${VARAUPDATE} || { echo "VARA Chat download failed! Please check your internet connection and re-run the script." && run_giveup; }
+					7z x ${VARAUPDATE}/VARA\ Chat*.zip -o"${VARAUPDATE}/VARAChatInstaller" -y -bsp0 -bso0
+
+				# Run the VARA Chat installer silently
+					echo -e "\n${GREENTXT}Installing VARA Chat . . .${NORMTXT}\n"
+					wine ${VARAUPDATE}/VARAChatInstaller/VARA\ Chat\ setup*.exe /SILENT # install VARA Chat
+				
+				# Clean up the installer
+					rm ${VARAUPDATE}/VARAChatInstaller/VARA\ Chat\ setup*.exe
+					sleep 3; sudo rm -rf ${HOME}/.local/share/applications/wine/Programs/VARA\ Chat/ # Remove VARA FM's auto-generated program icon from the start menu
+
+				# Make a VARA Chat desktop shortcut
+					echo '[Desktop Entry]'                                                                 | sudo tee ${STARTMENU}/vara-chat.desktop > /dev/null
+					echo 'Name=VARA Chat'                                                                  | sudo tee -a ${STARTMENU}/vara-chat.desktop > /dev/null
+					echo 'GenericName=VARA Chat'                                                           | sudo tee -a ${STARTMENU}/vara-chat.desktop > /dev/null
+					echo 'Comment=VARA Chat emulated with Box86/Wine'                                      | sudo tee -a ${STARTMENU}/vara-chat.desktop > /dev/null
+					echo 'Exec=env WINEDEBUG=-all wine '$HOME'/.wine/drive_c/VARA/VARA\ Chat.exe'          | sudo tee -a ${STARTMENU}/vara-chat.desktop > /dev/null
+					echo 'Type=Application'                                                                | sudo tee -a ${STARTMENU}/vara-chat.desktop > /dev/null
+					echo 'StartupNotify=true'                                                              | sudo tee -a ${STARTMENU}/vara-chat.desktop > /dev/null
+					echo 'Icon=DF53_VARA Chat.0'                                                           | sudo tee -a ${STARTMENU}/vara-chat.desktop > /dev/null
+					echo 'StartupWMClass=vara chat.exe'                                                    | sudo tee -a ${STARTMENU}/vara-chat.desktop > /dev/null
+					echo 'Categories=HamRadio'                                                             | sudo tee -a ${STARTMENU}/vara-chat.desktop > /dev/null
+
+			sudo rm -rf $VARAUPDATE
+			if [ "$SILENT" != "silent" ]; then
+				echo -e "\n${GREENTXT}Update complete . . .${NORMTXT}\n"
+			fi
+			sleep 5
+		else
+			: # If user selected not to update, then do nothing
+		fi
+	EOM
+	sudo chmod +x ${HOME}/winelink/Update\ VARA
+        
+        # Make a start menu shortcut for the Reset Wine script
+            echo '[Desktop Entry]'                                                                 | sudo tee ${STARTMENU}/vara-update.desktop > /dev/null
+            echo 'Name=Update VARA'                                                                | sudo tee -a ${STARTMENU}/vara-update.desktop > /dev/null
+            echo 'GenericName=Update VARA'                                                         | sudo tee -a ${STARTMENU}/vara-update.desktop > /dev/null
+            echo 'Comment=This script updates VARA HF/FM & VARA Chat'                              | sudo tee -a ${STARTMENU}/vara-update.desktop > /dev/null
+            echo 'Exec='$HOME'/winelink/Update\ VARA'                                              | sudo tee -a ${STARTMENU}/vara-update.desktop > /dev/null
+            echo 'Type=Application'                                                                | sudo tee -a ${STARTMENU}/vara-update.desktop > /dev/null
+            echo 'StartupNotify=true'                                                              | sudo tee -a ${STARTMENU}/vara-update.desktop > /dev/null
+            echo 'Categories=HamRadio;'                                                            | sudo tee -a ${STARTMENU}/vara-update.desktop > /dev/null
+}
+
+function run_varasoundcardsetup()
+{
+    bash ${HOME}/winelink/VARA\ Soundcard\ Setup
+}
+
+function run_makevarasoundcardsetupscript()
+{
+	cat > ${HOME}/winelink/VARA\ Soundcard\ Setup <<- 'EOM'
+		#!/bin/bash
+		
+		export WINEDEBUG=-all # silence winedbg for this instance of the terminal
+		sudo apt-get install zenity -y
+		
+		# Create directories (in case they don't already exist)
+			mkdir ${HOME}/winelink 2>/dev/null
+			mkdir ${HOME}/winelink/ahk 2>/dev/null
+		
+		# Set optional text colors
+    			GREENTXT='\e[32m' # Green
+    			NORMTXT='\e[0m' # Normal
+		
+		# Set location variables
+			AHK="${HOME}/winelink/ahk"
+		
+		# Guide the user to the wineconfig audio menu (configure hardware soundcard input/output)
+			clear
+			echo ""
+			echo -e "\n${GREENTXT}In winecfg, go to the Audio tab to set up your system's in/out soundcards.\n(please click 'Ok' on the user prompt textbox to continue)${NORMTXT}"
+			zenity --info --height 100 --width 350 --text="We will now setup your soundcards for Wine. \n\nPlease navigate to the Audio tab and choose your systems soundcards \n\nInstall will continue once you have closed the winecfg menu." --title="Wine Soundcard Setup"
+			echo -e "${GREENTXT}Loading winecfg now . . .${NORMTXT}\n"
+			echo ""
+			BOX86_NOBANNER=1 winecfg # nobanner just for prettier terminal
+		
+		# Guide the user to the VARA HF audio setup menu (configure hardware soundcard input/output)
+			clear
+			echo -e "\n${GREENTXT}Configuring VARA HF . . .${NORMTXT}\n"
+			echo -e "\n${GREENTXT}Please set up your soundcard input/output for VARA HF\n(please click 'Ok' on the user prompt textbox to continue)${NORMTXT}\n"
+			zenity --info --height 100 --width 350 --text="We will now setup your soundcards for VARA HF. \n\nInstall will continue once you have closed the VARA Settings menu." --title="VARA HF Soundcard Setup"
+			echo -e "\n${GREENTXT}Loading VARA HF now . . .${NORMTXT}\n"
+
+		# Create/run varahf_configure.ahk
+			# We will disable all graphics except gauges to help RPi4 CPU. Users can enable these if they have better CPU
+			# We will then open the soundcard menu for users so that they can set up their sound cards
+			# After the settings menu is closed, we will close VARA HF
+			echo '; AHK script to assist users in setting up VARA on its first run'                > ${AHK}/varahf_configure.ahk
+			echo 'SetTitleMatchMode, 2'                                                            >> ${AHK}/varahf_configure.ahk
+			echo 'SetTitleMatchMode, slow'                                                         >> ${AHK}/varahf_configure.ahk
+			echo '        Run, VARA.exe, C:\VARA'                                                  >> ${AHK}/varahf_configure.ahk
+			echo '        WinActivate, VARA HF'                                                    >> ${AHK}/varahf_configure.ahk
+			echo '        WinWait, VARA HF ; Wait for VARA HF to open'                             >> ${AHK}/varahf_configure.ahk
+			echo '        Sleep 2500 ; If we dont wait at least 2000 for VARA then AHK wont work'  >> ${AHK}/varahf_configure.ahk
+			echo '        Send, !{s} ; Open SoundCard menu for user to set up sound cards'         >> ${AHK}/varahf_configure.ahk
+			echo '        Sleep 500'                                                               >> ${AHK}/varahf_configure.ahk
+			echo '        Send, {Down}'                                                            >> ${AHK}/varahf_configure.ahk
+			echo '        Sleep, 100'                                                              >> ${AHK}/varahf_configure.ahk
+			echo '        Send, {Enter}'                                                           >> ${AHK}/varahf_configure.ahk
+			echo '        Sleep 5000'                                                              >> ${AHK}/varahf_configure.ahk
+			echo '        WinWaitClose, SoundCard ; Wait for user to finish setting up soundcard'  >> ${AHK}/varahf_configure.ahk
+			echo '        Sleep 100'                                                               >> ${AHK}/varahf_configure.ahk
+			echo '        WinClose, VARA HF ; Close VARA'                                          >> ${AHK}/varahf_configure.ahk
+			BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine ${HOME}/winelink/ahk/AutoHotkey.exe ${AHK}/varahf_configure.ahk # nobanner option to make console prettier
+			rm ${AHK}/varahf_configure.ahk
+			sleep 5
+		
+		# Turn off VARA HF's waterfall (change 'View=1' to 'View=3' in VARA.ini). INI file shows up after first run of VARA HF.
+			sed -i 's+View\=1+View\=3+g' ~/.wine/drive_c/VARA/VARA.ini
+		
+		# Guide the user to the VARA FM audio setup menu (configure hardware soundcard input/output)
+			clear
+			echo -e "\n${GREENTXT}Please set up your soundcard input/output for VARA FM\n(please click 'Ok' on the user prompt textbox to continue)${NORMTXT}\n"
+			zenity --info --height 100 --width 350 --text="We will now setup your soundcards for VARA FM. \n\nInstall will continue once you have closed the VARA Settings menu." --title="VARA FM Soundcard Setup"
+			echo -e "\n${GREENTXT}Loading VARA FM now . . .${NORMTXT}\n"
+		
+		#Create/run varafm_configure.ahk
+			# We will disable all graphics except gauges to help RPi4 CPU. Users can enable these if they have better CPU
+			# We will then open the soundcard menu for users so that they can set up their sound cards
+			# After the settings menu is closed, we will close VARA FM
+			echo '; AHK script to assist users in setting up VARA on its first run'                > ${AHK}/varafm_configure.ahk
+			echo 'SetTitleMatchMode, 2'                                                            >> ${AHK}/varafm_configure.ahk
+			echo 'SetTitleMatchMode, slow'                                                         >> ${AHK}/varafm_configure.ahk
+			echo '        Run, VARAFM.exe, C:\VARA FM'                                             >> ${AHK}/varafm_configure.ahk
+			echo '        WinActivate, VARA FM'                                                    >> ${AHK}/varafm_configure.ahk
+			echo '        WinWait, VARA FM ; Wait for VARA FM to open'                             >> ${AHK}/varafm_configure.ahk
+			echo '        Sleep 2000 ; If we dont wait at least 2000 for VARA then AHK wont work'  >> ${AHK}/varafm_configure.ahk
+			echo '        Send, !{s} ; Open SoundCard menu for user to set up sound cards'         >> ${AHK}/varafm_configure.ahk
+			echo '        Sleep 500'                                                               >> ${AHK}/varafm_configure.ahk
+			echo '        Send, {Down}'                                                            >> ${AHK}/varafm_configure.ahk
+			echo '        Sleep, 100'                                                              >> ${AHK}/varafm_configure.ahk
+			echo '        Send, {Enter}'                                                           >> ${AHK}/varafm_configure.ahk
+			echo '        Sleep 5000'                                                              >> ${AHK}/varafm_configure.ahk
+			echo '        WinWaitClose, SoundCard ; Wait for user to finish setting up soundcard'  >> ${AHK}/varafm_configure.ahk
+			echo '        Sleep 100'                                                               >> ${AHK}/varafm_configure.ahk
+			echo '        WinClose, VARA FM ; Close VARA'                                          >> ${AHK}/varafm_configure.ahk
+			BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine ${HOME}/winelink/ahk/AutoHotkey.exe ${AHK}/varafm_configure.ahk # Nobanner option to make console prettier
+			rm ${AHK}/varafm_configure.ahk
+			sleep 5
+			
+		clear
+		
+		# Turn off VARA FM's graphics (change 'View=1' to 'View=3' in VARAFM.ini). INI file shows up after first run of VARA FM
+			sed -i 's+View\=1+View\=3+g' ~/.wine/drive_c/VARA\ FM/VARAFM.ini
+	EOM
+	sudo chmod +x ${HOME}/winelink/VARA\ Soundcard\ Setup
+        
+        # Make a start menu shortcut for the Reset Wine script
+            echo '[Desktop Entry]'                                            | sudo tee ${STARTMENU}/vara-soundcardsetup.desktop > /dev/null
+            echo 'Name=VARA Soundcard Setup'                                  | sudo tee -a ${STARTMENU}/vara-soundcardsetup.desktop > /dev/null
+            echo 'GenericName=VARA Soundcard Setup'                           | sudo tee -a ${STARTMENU}/vara-soundcardsetup.desktop > /dev/null
+            echo 'Comment=This script helps users set up soundcards for VARA' | sudo tee -a ${STARTMENU}/vara-soundcardsetup.desktop > /dev/null
+            echo 'Exec='$HOME'/winelink/VARA\ Soundcard\ Setup'               | sudo tee -a ${STARTMENU}/vara-soundcardsetup.desktop > /dev/null
+            echo 'Type=Application'                                           | sudo tee -a ${STARTMENU}/vara-soundcardsetup.desktop > /dev/null
+            echo 'StartupNotify=true'                                         | sudo tee -a ${STARTMENU}/vara-soundcardsetup.desktop > /dev/null
+            echo 'Categories=HamRadio;'                                       | sudo tee -a ${STARTMENU}/vara-soundcardsetup.desktop > /dev/null
 }
 
 function run_makewineserverkscript()  # Make a script for the desktop that will rest wine in case it freezes/crashes
 {
     sudo apt-get install zenity -y
     # Create 'Reset\ Wine.sh'
-        echo '#!/bin/bash'   >> ~/Desktop/Reset\ Wine
-        echo ''              >> ~/Desktop/Reset\ Wine
-        echo 'wineserver -k' >> ~/Desktop/Reset\ Wine
-        echo 'zenity --info --timeout=8 --height 150 --width 500 --text="Wine has been reset so that Winlink Express and VARA will run again.\\n\\nIf you try to run RMS Express again and it crashes or doesn'\''t open, just keep trying to run it.  It should open eventually after enough tries." --title="Wine has been reset"'          >> ~/Desktop/Reset\ Wine
-        sudo chmod +x ~/Desktop/Reset\ Wine
+        echo '#!/bin/bash'               > ${HOME}/winelink/Reset\ Wine
+        echo ''                          >> ${HOME}/winelink/Reset\ Wine
+        echo 'wineserver -k'             >> ${HOME}/winelink/Reset\ Wine
+        echo 'zenity --info --timeout=8 --height 150 --width 500 --text="Wine has been reset so that Winlink Express and VARA will run again.\\n\\nIf you try to run RMS Express again and it crashes or doesn'\''t open, just keep trying to run it.  It should open eventually after enough tries." --title="Wine has been reset"'          >> ${HOME}/winelink/Reset\ Wine
+        sudo chmod +x ${HOME}/winelink/Reset\ Wine
+	
+    # Make a start menu shortcut for the Reset Wine script
+        echo '[Desktop Entry]'                                              | sudo tee ${STARTMENU}/resetwine.desktop > /dev/null
+        echo 'Name=Reset Wine'                                              | sudo tee -a ${STARTMENU}/resetwine.desktop > /dev/null
+        echo 'GenericName=Reset Wine'                                       | sudo tee -a ${STARTMENU}/resetwine.desktop > /dev/null
+        echo 'Comment=A reset button in case VARA or RMS Express freeze'    | sudo tee -a ${STARTMENU}/resetwine.desktop > /dev/null
+        echo 'Exec='$HOME'/winelink/Reset\ Wine'                            | sudo tee -a ${STARTMENU}/resetwine.desktop > /dev/null
+        echo 'Type=Application'                                             | sudo tee -a ${STARTMENU}/resetwine.desktop > /dev/null
+        echo 'StartupNotify=true'                                           | sudo tee -a ${STARTMENU}/resetwine.desktop > /dev/null
+        echo 'Categories=HamRadio;'                                         | sudo tee -a ${STARTMENU}/resetwine.desktop > /dev/null
 }
 
-function run_makevaraupdatescript()
+function run_makeuninstallscript()
 {
-	# Create 'Update\ VARA.sh'
-	
-	# Inject code into a new script that can be run later from the desktop by users who wish to update VARA HF, VARA FM, and VARAChat
-	#   Note that this script uses tabs (	) instead of spaces ( ) for formatting since it relies on heredoc (i.e. eom & eot).
-	#   Also note that none of this code gets run right now.
-	cat > $HOME/Desktop/Update\ VARA <<- 'EOM'
+	cat > ${HOME}/winelink/Uninstall\ Winelink <<- 'EOM'
 		#!/bin/bash
 		
-		sudo apt-get install zenity curl megatools p7zip-full -y &
-		sudo rm -rf ~/vara_update_files 2>/dev/null # remove any failed vara update attempts
+		sudo apt-get install zenity -y
+		STARTMENU="/usr/share/applications" # Program shortcuts/icons can go here
 		
-		if zenity --question --height 150 --width 500 --text="Would you like to update VARA HF, VARA FM, and VARA Chat?\\n\\n(RMS Express already checks for updates on its own)" --title="Update VARA Suite?"
+		zenity --question --height 150 --width 500 --text="Are you sure you would like to uninstall Winelink?\\n(Uninstall VARA HF/FM/Chat, &amp; RMS Express?)" --title="Uninstall Winelink?"
+		UNWL=$? # the answer of the yes/no questions is stored in the $? variable ( 0 = yes, 1 = no ).
+		if	[ "$UNWL" = 0 ]; # If user answered 'yes', then ...
 		then
-			zenity --warning --timeout=16 --height 150 --width 500 --text="Updating VARA HF, VARA FM, and VARA Chat now ...\\n\\nThis may take a moment." --title="Updating VARA Suite" &
-			mkdir ~/vara_update_files 2>/dev/null; cd ~/vara_update_files # start new vara update
-				# Download / extract VARA HF
-					# files: VARA HF v4.4.3 Setup > VARA setup (Run as Administrator).exe > /SILENT install has an OK button at end
-					echo -e "\n${GREENTXT}Downloading VARA HF . . .${NORMTXT}\n"
-					VARAHFLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA HF v)') # Find the mega.nz link from the rosmodem website no matter its version, then store it as a variable
-					megadl ${VARAHFLINK} || zenity --warning --timeout=8 --height 150 --width 500 --text="VARA HF download failed ..." --title="Download failed"
-					7z x VARA\ HF*.zip -o"VARAHFInstaller"
-					cp VARAHFInstaller/VARA\ setup*.exe ~/.wine/drive_c/ # move VARA installer here (so AHK can find it later)
-					# VARA HF will be installed with an AHK script later
+			sudo rm ${STARTMENU}/resetwine.desktop ${STARTMENU}/vara-update.desktop ${STARTMENU}/vara.desktop ${STARTMENU}/vara-chat.desktop \
+				${STARTMENU}/vara-fm.desktop ${STARTMENU}/winlinkexpress.desktop ${STARTMENU}/vara-soundcardsetup.desktop 2>/dev/null # remove old shortcuts
+			sudo rm -rf ${HOME}/winelink 2>/dev/null
 
-				# Download / extract VARA FM
-					# files: VARA FM v4.1.3 Setup.zip > VARA FM setup (Run as Administrator).exe > /SILENT install has an OK button at end
-					echo -e "\n${GREENTXT}Downloading VARA FM . . .${NORMTXT}\n"
-					VARAFMLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA FM v)') # Find the mega.nz link from the rosmodem website no matter its version, then store it as a variable
-					megadl ${VARAFMLINK} || zenity --warning --timeout=8 --height 150 --width 500 --text="VARA FM download failed ..." --title="Download failed"
-					7z x VARA\ FM*.zip -o"VARAFMInstaller"
-					cp VARAFMInstaller/VARA\ FM\ setup*.exe ~/.wine/drive_c/ # move VARA installer here (so AHK can find it later)
-					# VARA FM will be installed with an AHK script later
+			# Ask user if they would like to remove wine & box86
+				zenity --question --height 150 --width 500 --text="Winelink uninstalled\\n\\nWould you also like to remove Wine and Box86?" --title="Remove Wine & Box86?"
+				UNWINE=$? # the answer of the yes/no questions is stored in the $? variable ( 0 = yes, 1 = no ).
+				if	[ "$UNWINE" = 0 ]; # If user answered 'yes', then ...
+				then
+					sudo rm -rf ${HOME}/.wine ${HOME}/.wine-old ${HOME}/wine ${HOME}/wine-old 2>/dev/null
+					sudo rm /usr/local/bin/wine /usr/local/bin/wineboot /usr/local/bin/winecfg /usr/local/bin/wineserver /usr/local/bin/winetricks 2>/dev/null
+					sudo rm /usr/local/bin/wine-old /usr/local/bin/wineboot-old /usr/local/bin/winecfg-old /usr/local/bin/wineserver-old /usr/local/bin/winetricks-old 2>/dev/null
 
-				mkdir ahk; cd ahk
-					# Download AutoHotKey
-						wget -q https://github.com/AutoHotkey/AutoHotkey/releases/download/v1.0.48.05/AutoHotkey104805_Install.exe  || zenity --warning --timeout=8 --height 150 --width 500 --text="AHK download failed ..." --title="Download failed"
-						7z x AutoHotkey104805_Install.exe AutoHotkey.exe
-						sudo chmod +x AutoHotkey.exe
-
-					# Install VARA HF silently
-						# Create varahf_install.ahk
-						# The VARA installer prompts the user to hit 'OK' even during silent install (due to a secondary installer).  We will suppress this prompt with AHK.
-						echo '; AHK script to make VARA installer run completely silent'						>> varahf_install.ahk
-						echo 'SetTitleMatchMode, 2'																>> varahf_install.ahk
-						echo 'SetTitleMatchMode, slow'															>> varahf_install.ahk
-						echo '		Run, VARA setup (Run as Administrator).exe /SILENT, C:\'					>> varahf_install.ahk
-						echo '		WinWait, VARA Setup ; Wait for the "VARA installed successfully" window'	>> varahf_install.ahk
-						echo '		ControlClick, Button1, VARA Setup ; Click the OK button'					>> varahf_install.ahk
-						echo '		WinWaitClose'																>> varahf_install.ahk
-
-						# Run varahf_install.ahk
-						echo -e "\n${GREENTXT}Installing VARA HF . . .${NORMTXT}\n"
-						BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine AutoHotkey.exe varahf_install.ahk # install VARA silently using AHK
-						rm ~/.wine/drive_c/VARA\ setup*.exe # clean up
-
-						# Make a VARA HF desktop shortcut
-						echo '[Desktop Entry]'																	>> ~/Desktop/VARA.desktop
-						echo 'Name=VARA'																		>> ~/Desktop/VARA.desktop
-						echo 'Exec=wine '$HOME'/.wine/drive_c/VARA/VARA.exe'									>> ~/Desktop/VARA.desktop
-						echo 'Type=Application'																	>> ~/Desktop/VARA.desktop
-						echo 'StartupNotify=true'																>> ~/Desktop/VARA.desktop
-						echo 'Icon=F302_VARA.0'																	>> ~/Desktop/VARA.desktop
-						echo 'StartupWMClass=vara.exe'															>> ~/Desktop/VARA.desktop
-						#cp ~/.local/share/applications/wine/Programs/VARA/VARA.desktop ~/Desktop/ # wine makes broken shortcuts sometimes
-						sudo chmod +x ~/Desktop/VARA.desktop
-
-					# Install VARA FM silently
-						# Create/run varafm_install.ahk
-						# The VARA installer prompts the user to hit 'OK' even during silent install (due to a secondary installer).  We will suppress this prompt with AHK.
-						echo '; AHK script to make VARA installer run completely silent'						>> varafm_install.ahk
-						echo 'SetTitleMatchMode, 2'																>> varafm_install.ahk
-						echo 'SetTitleMatchMode, slow'															>> varafm_install.ahk
-						echo '		Run, VARA FM setup (Run as Administrator).exe /SILENT, C:\'					>> varafm_install.ahk
-						echo '		WinWait, VARA Setup ; Wait for the "VARA installed successfully" window'	>> varafm_install.ahk
-						echo '		ControlClick, Button1, VARA Setup ; Click the OK button'					>> varafm_install.ahk
-						echo '		WinWaitClose'																>> varafm_install.ahk
-
-						# Run varafm_install.ahk
-						echo -e "\n${GREENTXT}Installing VARA FM . . .${NORMTXT}\n"
-						BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine AutoHotkey.exe varafm_install.ahk # install VARA silently using AHK
-						rm ~/.wine/drive_c/VARA\ FM\ setup*.exe # clean up
-				cd ..
-
-				# Download / extract / install VARA Chat
-					# files: VARA Chat v1.2.5 Setup.zip > VARA Chat setup (Run as Administrator).exe > /SILENT install is silent
-					echo -e "\n${GREENTXT}Downloading VARA Chat . . .${NORMTXT}\n"
-					VARACHATLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA Chat v)') # Find the mega.nz link from the rosmodem website no matter its version, then store it as a variable
-					megadl ${VARACHATLINK} || zenity --warning --timeout=8 --height 150 --width 500 --text="VARA Chat download failed ..." --title="Download failed"
-					7z x VARA\ Chat*.zip -o"VARAChatInstaller"
-
-					echo -e "\n${GREENTXT}Installing VARA Chat . . .${NORMTXT}\n"
-					wine VARAChatInstaller/VARA\ Chat\ setup*.exe /SILENT # install VARA Chat
-			cd ..
-			sudo rm -rf ~/vara_update_files
-		else
-			: # do nothing
+					sudo rm /usr/local/bin/box86 2>/dev/null
+					sudo rm /etc/binfmt.d/box86.conf 2>/dev/null
+					sudo systemctl restart systemd-binfmt # unregister box86 from binfmt-misc
+				fi
+			echo "Uninstall complete"
 		fi
 	EOM
-	sudo chmod +x ~/Desktop/Update\ VARA
+	sudo chmod +x ${HOME}/winelink/Uninstall\ Winelink
 }
 
 function run_detect_arch()  # Finds what kind of processor we're running (aarch64, armv8l, armv7l, x86_64, x86, etc)
@@ -718,21 +781,30 @@ function run_gather_os_info()
 
 function run_giveup()  # If our script failed at any critical stages, notify the user and quit
 {
-     echo ""
-     echo "Installation failed."
-     echo ""
-     echo "For help, please reference the 'winelink.log' file"
-     echo "You can also open an issue on github.com/WheezyE/Winelink/"
-     echo ""
-     read -n 1 -s -r -p "Press any key to quit . . ."
-     echo ""
-     exit
+    echo ""
+    echo "Winelink installation failed."
+    echo ""
+    echo "For help, please reference the 'winelink.log' file"
+    echo "You can also open an issue on github.com/WheezyE/Winelink/"
+    echo ""
+    exit
 }
 
 # Set optional text colors
-GREENTXT='\e[32m' # Green
-NORMTXT='\e[0m' # Normal
-BRIGHT='\e[7m' # Highlighted
-NORMAL='\e[0m' # Non-highlighted
+    GREENTXT='\e[32m' # Green
+    NORMTXT='\e[0m' # Normal
+    BRIGHT='\e[7m' # Highlighted
+    NORMAL='\e[0m' # Non-highlighted
+
+# Set location variables (these also must be set separately within HEREDOC scripts)
+    AHK="${HOME}/winelink/ahk"
+    # - Start menu organization: https://specifications.freedesktop.org/menu-spec/menu-spec-1.0.html
+    STARTMENU="/usr/share/applications" # Program shortcuts/icons can go here
+    STARTMENU2="/usr/local/share/applications" # Program shortcuts/icons can go here
+    FOLDERSMENU="/usr/share/desktop-directories" # Info about submenu's goes here (the submenu is essentially its own icon).
+    ADDSUBMENU="/usr/share/extra-xdg-menus" # Create a new xml file and place here to have it merged by xdg
+                                            # bap submenu entry: https://github.com/km4ack/pi-build/blob/7d5c407c14e3bceec672b06b1c3e85f64bba137f/menu-update#L164
+    COMPLETEMENU="/etc/xdg/menus/applications-merged" # Completed menu stored here after merging?
+
 
 run_main "$@"; exit # Run the "run_main" function after all other functions have been defined in bash.  This allows us to keep our main code at the top of the script.


### PR DESCRIPTION
Add BAP compatability to Winelink
 - Update estimated install time
 - Make terminal less verbose (mostly just silence winedbg & 7z)
 - Put ahk download & soundcard setup in their own functions
 - Give winelink its own directory for ahk/scripts
 - Give the Update VARA script a 'silent' option & make it the default VARA installer (consolodate script subroutines)
 - Fix some typo's, formatting, user messages
 - Move program icons into the start menu
 - Remove Wine's weird auto-generated program icons
 - Remove unused vARIM subroutine
 - Firmcode some paths (working on letting user run the script from any location)
 - Make all >> first lines a > (prevent accidental ahk repetitions)
 - Make an uninstall script
 - bump version
 - Update README.md