### PR TITLE
Update install_winelink.sh, readme, add box86 binary

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,11 @@
 ![logo](WinelinkLogo.png "Project logo")
-# Winelink
+# Winɘlink
 A [Winlink](http://winlink.org/) (RMS Express & VARA) installer Script for the Raspberry Pi 4.
 
-_This project is very early in development. It has lots of bugs and should be considered [alpha](https://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha) software._
+_This project has lots of bugs and should be considered [alpha](https://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha) software._
+
+![VARA-Pi4](VARA-Pi4.png "VARA running on a Raspberry Pi 4B (Twister OS)")
+_VARA running on a Raspberry Pi 4B (Twister OS)_
 
 ## Installation
 Copy/paste these commands into your Raspberry Pi 4's terminal:
@@ -13,17 +16,8 @@ curl -O https://raw.githubusercontent.com/WheezyE/Winelink/main/install_winelink
  - A full installation takes about 10 minutes (with user prompts)
  - If desired, you can tell the script to only install VARA by running `curl -O https://raw.githubusercontent.com/WheezyE/Winelink/main/install_winelink.sh && bash install_winelink.sh vara_only`
 
-## Examples
-![VARA-Pi4](VARA-Pi4.png "VARA running on a Raspberry Pi 4B (Twister OS)")
-VARA running on a Raspberry Pi 4B (Twister OS)
-
-## How it works
-This script will help you install Box86, Wine, winetricks, Windows DLL's, RMS Express, & VARA.  You will then be prompted to configure RMS Express & VARA to send/receive audio from a USB sound card plugged into your Pi.  This installer will only work on the Raspberry Pi 4B for now (support for earlier Raspberry Pi models is planned for later).
-
-To run Windows .exe files on RPi4 (ARM/Linux), we need an x86 emulator ([Box86](https://github.com/ptitSeb/box86)) and a Windows API Call interpreter ([Wine](https://github.com/wine-mirror/wine)).  Box86 is open-source and runs about 10x faster than [ExaGear](https://www.huaweicloud.com/kunpeng/software/exagear.html) or [Qemu](https://github.com/qemu/qemu).  ExaGear is also closed source abandonware and Qemu (qemu-system & qemu-user-static) also has issues running more complex Wine programs on the Pi.  Box86 is much smaller in file size and much easier to install too.
-
 ## Known issues
- - ARDOP & VARA often have trouble connecting to RMS Express (over local TCP) when they first start up. Just restart RMS Express until they do connect (this is a bug in wine).
+ - ARDOP & VARA often have trouble connecting to RMS Express (over local TCP) when they first start up. Just restart them through RMS Express until they do connect (this is a bug in wine).
  - VARA's CPU gauge doesn't display (this is a bug in wine).
  - VARA doesn't connect to DRA boards at this time (this might be a bug in wine or box86).
  - Enabling VARA HF's waterfall display can sometimes crash VARA & RMS Express.
@@ -36,6 +30,7 @@ To run Windows .exe files on RPi4 (ARM/Linux), we need an x86 emulator ([Box86](
 >       icecream95, SpacingBat3, Botspot, Icenowy, Longhorn, et.al.)
 
  - [madewokherd](https://github.com/madewokherd/wine-mono) (Esme) for wine-mono debugging
+ - [Botspot](https://github.com/Botspot/) for their RPi3 kernel switching code
  - N7ACW, AD7HE, & KK6FVG for getting me started in ham radio
  - [KM4ACK](https://github.com/km4ack/pi-build) & [OH8STN](https://oh8stn.org/) for inspiration
  - [K6ETA](http://k6eta.com/linux/installing-rms-express-on-linux-with-wine) & [DCJ21](https://dcj21net.wordpress.com/2016/06/17/install-rms-express-linux/)'s 'Winlink on Linux' guides for early proof-of-concept
@@ -43,12 +38,32 @@ To run Windows .exe files on RPi4 (ARM/Linux), we need an x86 emulator ([Box86](
          "My humanity is bound up in yours, for we can only be human together"
                                                      - Nelson Mandela
 
-## Legal
-All software used by this script is free and legal to use (with the exception of VARA, of course, which is shareware).  Box86, Wine, wine-mono, winetricks, and AutoHotKey, are all open-source (which avoids the legal problems of use & distribution that ExaGear had - ExaGear also ran much slower than Box86 and is no-longer maintained, despite what Huawei says these days).  All proprietary Windows DLL files required by Wine are downloaded directly from Microsoft and installed according to their redistribution guidelines.  Raspberry Pi is a trademark of the Raspberry Pi Foundation
 
-## Future work
+## Donations
+If you feel that you are able and would like to support this project, please consider sending donations to ptitSeb, madewokherd (CodeWeavers/WineHQ), or KM4ACK - without whom, this script would not exist.
+ - Sebastien "ptitSeb" Chevalier (author of [Box86](https://github.com/ptitSeb/box86), incredible developer, & really nice guy) [paypal.me/0ptitSeb](paypal.me/0ptitSeb)
+ - Madewokherd (author of [wine-mono](https://github.com/madewokherd/wine-mono) & wonderful person) [https://www.winehq.org/donate](https://www.winehq.org/donate)
+ - Jason "KM4ACK" Oleham (author of [Build-a-Pi](https://github.com/km4ack/pi-build), Linux elmer, & ham radio pioneer) [paypal.me/km4ack](paypal.me/km4ack)
+
+## Stuff for nerds
+<details><summary>How it works</summary>
+
+This script will help you install Box86, Wine, winetricks, Windows DLL's, RMS Express, & VARA.  You will then be prompted to configure RMS Express & VARA to send/receive audio from a USB sound card plugged into your Pi.  This installer will only work on the Raspberry Pi 4B for now (support for earlier Raspberry Pi models is planned for later).
+
+To run Windows .exe files on RPi4 (ARM/Linux), we need an x86 emulator ([Box86](https://github.com/ptitSeb/box86)) and a Windows API Call interpreter ([Wine](https://github.com/wine-mirror/wine)).  Box86 is open-source and runs about 5x faster than [ExaGear](https://www.huaweicloud.com/kunpeng/software/exagear.html)/[Qemu](https://github.com/qemu/qemu) (see [these benchmarks](https://box86.org/2022/03/box86-box64-vs-qemu-vs-fex-vs-rosetta2/)).  ExaGear is also closed source abandonware and Qemu (qemu-system & qemu-user-static) also has issues running more complex Wine programs on the Pi.  Box86 is much smaller in file size and much easier to install too.
+</details>
+
+<details><summary>Distribution</summary>
+
+If you use this script in your project (or are inspired by it) just please be sure to mention ptitSeb, Box86, and myself (KI7POL).  This script is free to use, open-source, and should not be monetized (for further information see the [license file](LICENSE)).
+</details>
+
+<details><summary>Future Work: Roadmap</summary>
+
  - [ ] Add an AHK script to help the user with ARDOP first time soundcard setup.
- - [ ] Switch to using Seb's GitHub box86 binaries instead of Pale's internet archive binaries.
+ - [ ] Add HDD-space check to make sure user has enough space to install everything
+ - [ ] Time all individual components and embed comments in functions for Pi models. Add variable timer to welcome screen.
+ - [ ] Switch to using Seb's GitHub box86 binaries (or hosted box86 bins) instead of Pale's internet archive binaries.
  - [ ] Help DRA-board compatability with VARA ([might be a box86 issue?](https://github.com/ptitSeb/box86/issues/567))
  - [ ] Bisect box86 commits that crash VARA's local TCP to RMS connection (bug in newer box86's)
  - [ ] Add updated example images.
@@ -91,33 +106,35 @@ All software used by this script is free and legal to use (with the exception of
   - [x] Add pdhNT4 to [winetricks](https://github.com/Winetricks/winetricks) to streamline this installer.
   - [x] Make code modular to help readability.
  - [x] Simplify installation commands (model after KM4ACK BAP).
- #### Add more platforms (make a multi-platform [Wine](https://wiki.winehq.org/Download) installer & build/invoke box86 if needed).
+</details>
+
+<details><summary>Future work: More platforms</summary>
+     
+Make a multi-platform [Wine](https://wiki.winehq.org/Download) installer & build/invoke box86 if needed. ([Linode](https://www.linode.com/company/about/#row--about) may be helpful here)
+     
  - [x] Auto-detection of system arch (x86 vs armhf vs aarch64) & OS.
     - ARM
       - [x] Raspberry Pi 4B (32-bit OS)
       - [ ] Raspberry Pi 4B (64-bit OS)
-      - [ ] Raspberry Pi 3B+
-        - [ ] Detect Raspberry Pi kernel memory split (and install the correct kernel if needed) for RPi <4 support.
-        - [ ] Ask Botspot if I can borrow some of his [pi-apps code](https://github.com/Botspot/pi-apps/blob/4a48ba62b157420c6e33666e7d050ee3ce21ab0b/apps/Wine%20(x86)/install-32#L165).
+      - [x] Raspberry Pi 3B+
+        - [x] Detect Raspberry Pi kernel memory split (and install the correct kernel if needed) for RPi <4 support.
+        - [x] Ask Botspot if I can borrow some of his [pi-apps code](https://github.com/Botspot/pi-apps/blob/4a48ba62b157420c6e33666e7d050ee3ce21ab0b/apps/Wine%20(x86)/install-32#L165).
       - [ ] RPi Zero 2 W?
       - [ ] RPi Zero W?
       - [ ] [Termux](https://github.com/termux/termux-app) (Android without root) ([proot-distro](https://github.com/termux/proot-distro) + Ubuntu ARM + [termux-usb](https://wiki.termux.com/wiki/Termux-usb)) - see [AnBox86](https://github.com/lowspecman420/AnBox86) for proof of concept, currently untested with VARA.
-        - [x] Fix AnBox86
-        - [x] [Proof-of-concept](https://www.youtube.com/watch?v=FkeP_IW3GGQ&t=29s)
-        - [ ] ~See if termux-usb can be adapted somehow to allow connections without root?~
-      - [ ] [Box86Launcher](https://github.com/AllPlatform/Box86Launcher) (Android -- root?)
       - [ ] Mac M1 processors
     - x86
       - Mac
         - [ ] OSX?
       - Linux (top priorities are distros that WineHQ hosts binaries for: Ubuntu, Debian, Fedora, macOS, SUSE, Slackware, and FreeBSD)
         - [ ] Ubuntu (Package manager: apt)
-          - [x] Linux Mint
+          - [ ] Linux Mint
           - [ ] Elementary OS
           - [ ] Zorin OS
         - [ ] Debian (Package manager: apt)
           - [ ] Deepin
           - [ ] Kali
+          - [ ] MX-Linux
         - [ ] Red Hat (Package manager: yum, RPM)
           - [ ] Fedora (Package manager: RPM/DNF)
           - [ ] CentOS (Package manager: yum)
@@ -133,21 +150,30 @@ All software used by this script is free and legal to use (with the exception of
         - [ ] Solus (Package manager: eopkg)
       - [ ] ChromeBook Linux beta.
         - [ ] Try to detect if processor would be too slow?
+    - x64
+      - Linux (top priorities are distros that WineHQ hosts binaries for: Ubuntu, Debian, Fedora, macOS, SUSE, Slackware, and FreeBSD)
+        - [x] Linux Mint
+        - [x] Debian 11
  - [ ] Make a youtube video showcasing current methods (box86, Exagear issues, qemu-user-static errors, Pi4B, Pi3B+, Termux, Mac, Linux, ChromeOS)
- 
- - Android testing notes (Termux/PRoot/AnBox86_64)
-     - [ ] Termux-usb seems to need root to really work. See if there is a work-around for no root?
-     - [ ] Create alpha version of Winelink for AnBox86_64
-     - [ ] Speed benchmarks with different devices (Fire HD10 Tablet is a bit slow, Retroid Pocket 2 TBD)
-     - [x] OTG-USB-CAT (order OTG_USB_C-USB)
-     - [x] Audio in/out (ARDOP works with alsa / hiccups with pulseaudio)
-     - [x] Proof of concept https://youtu.be/FkeP_IW3GGQ?t=23
+</details>
+     
+<details><summary>Android testing notes</summary>
 
-## Distribution
-If you use this script in your project (or are inspired by it) just please be sure to mention ptitSeb, Box86, and myself (KI7POL).  This script is free to use, open-source, and should not be monetized (for further information see the [license file](LICENSE)).
+Termux/PRoot/AnBox86_64
 
-## Donations
-If you feel that you are able and would like to support this project, please consider sending donations to ptitSeb, madewokherd (CodeWeavers/WineHQ), or KM4ACK - without whom, this script would not exist.
- - Sebastien "ptitSeb" Chevalier (author of [Box86](https://github.com/ptitSeb/box86), incredible developer, & really nice guy) [paypal.me/0ptitSeb](paypal.me/0ptitSeb)
- - Madewokherd (author of [wine-mono](https://github.com/madewokherd/wine-mono) & wonderful person) [https://www.winehq.org/donate](https://www.winehq.org/donate)
- - Jason "KM4ACK" Oleham (author of [Build-a-Pi](https://github.com/km4ack/pi-build), Linux elmer, & ham radio pioneer) [paypal.me/km4ack](paypal.me/km4ack)
+ - [ ] Try using [BT/USB/TCP Bridge Pro](https://play.google.com/store/apps/details?id=masar.bluetoothbridge.pro) to connect USB devices to RMS Express (credits: Torsten, DL1THM / [harenber](https://github.com/harenber/ptc-go/wiki/Android))
+ - [ ] Create alpha version of Winelink for AnBox86_64
+ - [ ] Speed benchmarks with different devices (Fire HD10 Tablet is a bit slow, Retroid Pocket 2 TBD)
+ - [ ] ~See if termux-usb can be adapted somehow to allow connections without root?~
+ - [ ] See if [a python wrapper](https://github.com/Querela/termux-usb-python/issues/4) could be written for TermuxUSB-OTG-USB connections between RMS Express & FT-891.
+ - [x] OTG-USB-CAT (order OTG_USB_C-USB)
+ - [x] Audio in/out (ARDOP works with alsa / hiccups with pulseaudio)
+ - [x] [Proof-of-concept](https://www.youtube.com/watch?v=FkeP_IW3GGQ&t=29s)
+ - [x] Fix AnBox86
+     
+</details>
+     
+<details><summary>Legal</summary>
+
+All software used by this script is free and legal to use (with the exception of VARA, of course, which is shareware).  Box86, Wine, wine-mono, winetricks, and AutoHotKey, are all open-source (which avoids the legal problems of use & distribution that ExaGear had - ExaGear also ran much slower than Box86 and is no-longer maintained, despite what Huawei says these days).  All proprietary Windows DLL files required by Wine are downloaded directly from Microsoft and installed according to their redistribution guidelines.  Raspberry Pi is a trademark of the Raspberry Pi Foundation
+</details>

--- a/docs/experiments/debian_x86-ttyUSB_dialout_permissions.txt
+++ b/docs/experiments/debian_x86-ttyUSB_dialout_permissions.txt
@@ -1,0 +1,83 @@
+PTT from Windows laptop works on Windows w/ ARDOP.
+PTT from Linux+wine x86 VM (running within laptop) doesn't work w/ ARDOP.
+ - Same behavior with mono or dotnet46.
+ - Wine does detect the FT-891's COM ports (USB ports) but can't access them.
+ - Debian needed user permissions to be added to the USB dialout group (this is not a problem on RaspberryPi OS though on Pi4)
+
+---- 
+
+sudo apt install setserial
+		FT-891 serial connection is named: "silicon cp2105 dual usb to uart bridge controller"
+
+ttyUSB0 & ttyUSB1 are not listed before connecting the FT-891 to the laptop running the VM. They are listed after connecting.
+		pi@debian:/dev$ sudo dmesg | grep tty
+		[    0.093140] console [tty0] enabled
+		[    1.438158] 00:05: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
+		[    2.796210] systemd[1]: Created slice system-getty.slice.
+		[ 3808.551827] usb 1-2.2: cp210x converter now attached to ttyUSB0
+		[ 3808.563798] usb 1-2.2: cp210x converter now attached to ttyUSB1
+		
+		pi@debian:/dev$ ls tty*
+		tty    tty14  tty20  tty27  tty33  tty4   tty46  tty52  tty59  tty8     ttyUSB1
+		tty0   tty15  tty21  tty28  tty34  tty40  tty47  tty53  tty6   tty9
+		tty1   tty16  tty22  tty29  tty35  tty41  tty48  tty54  tty60  ttyS0
+		tty10  tty17  tty23  tty3   tty36  tty42  tty49  tty55  tty61  ttyS1
+		tty11  tty18  tty24  tty30  tty37  tty43  tty5   tty56  tty62  ttyS2
+		tty12  tty19  tty25  tty31  tty38  tty44  tty50  tty57  tty63  ttyS3
+		tty13  tty2   tty26  tty32  tty39  tty45  tty51  tty58  tty7   ttyUSB0
+
+`wine regedit` registry key "HKEY_LOCAL_MACHINE\Software\Wine\Ports" is empty.
+
+Checking wine's com port symlinks (wine already linked its com5 & com6 to the FT-891's ttyUSB0 & ttyUSB1):
+		pi@debian:~/.wine/dosdevices$ ls
+		c:  com1  com2  com3  com4  com5  com6  d:  d::  z:
+		pi@debian:~/.wine/dosdevices$ ls -l com1
+		lrwxrwxrwx 1 pi pi 10 Jan  3 19:03 com1 -> /dev/ttyS0
+		pi@debian:~/.wine/dosdevices$ ls -l com2
+		lrwxrwxrwx 1 pi pi 10 Jan  3 19:03 com2 -> /dev/ttyS1
+		pi@debian:~/.wine/dosdevices$ ls -l com3
+		lrwxrwxrwx 1 pi pi 10 Jan  3 19:03 com3 -> /dev/ttyS2
+		pi@debian:~/.wine/dosdevices$ ls -l com4
+		lrwxrwxrwx 1 pi pi 10 Jan  3 19:03 com4 -> /dev/ttyS3
+		pi@debian:~/.wine/dosdevices$ ls -l com5
+		lrwxrwxrwx 1 pi pi 12 Jan  3 19:03 com5 -> /dev/ttyUSB0
+		pi@debian:~/.wine/dosdevices$ ls -l com6
+		lrwxrwxrwx 1 pi pi 12 Jan  3 19:03 com6 -> /dev/ttyUSB1
+	
+When setting ARDOP to use COM6 (wine's com6 symlink) to try to talk to the FT-891's USB port, ARDOP says no connection could be made and to check the exceptions log.
+
+The ARDOP exceptions log says:
+		pi@debian:~/.wine/drive_c/RMS Express/KI7POL/Logs$ more RMS\ Express\ Exceptions\ 20220104.log 
+		2022/01/04 02:17:56 [1.5.44.0] [Radio.SendASCIICommand] Err:
+		2022/01/04 02:18:05 [1.5.44.0] [Radio.OpenControlPort]
+
+Trying to start a winlink connection with ARDOP plays tones, but doesn't trigger radio's "push-to-talk" (PTT) since the radio's USB isn't accssible.
+
+-------------------------------------------------------------------
+Check permissions on the FT-891's serial port to see if non-root users can access it:
+		pi@debian:~/.wine/drive_c/RMS Express/KI7POL/Logs$ ls -l /dev/ttyUSB1
+		crw-rw---- 1 root dialout 188, 1 Jan  3 19:50 /dev/ttyUSB1
+Guess not (only 'root' and 'dialout' have access?)
+
+	sudo adduser <the user you want to add> dialout
+Try opening ARDOP again - COM6 access still denied.
+	sudo reboot
+Try opening ARDOP again - COM6 access still denied, but no more permission errors pop up with winlink.
+	sudo usermod -a -G dialout $USER
+Try opening ARDOP again - COM6 access still denied, but no more permission errors pop up with winlink.
+	sudo reboot
+Try opening ARDOP again - COM6 access still denied, but no more permission errors pop up with winlink.
+Set COM5, same.
+
+Play with ARDOP settings some more: Setting COM5 and PTT "FT-891" works!
+ - PTT on transmit works.
+ - Channel selection browser: When selecting a channel, the radio changes to that channel! :)
+ - Setting to COM6 and PTT "FT-891" doesn't work
+
+TODO: Test this with mono. Mono used to have USB errors but I think this was fixed after Feb 1, 2022.
+
+
+K6ETAadd for permissions (suggested by Jouko/OH5RM):
+sudo usermod -a -G dialout $USERNAME
+sudo usermod -a -G tty $USERNAME
+sudo usermod -a -G audio $USERNAME

--- a/install_winelink.sh
+++ b/install_winelink.sh
@@ -1,30 +1,9 @@
 #!/bin/bash
 
-function run_greeting()
-{
-    clear
-    echo ""
-    echo "########### Winlink & VARA Installer Script for the Raspberry Pi 4B ###########"
-    echo "# Author: Eric Wiessner (KI7POL)                    Install time: apx 10 min  #"
-    echo "# Version: 0.0090a                                                            #"
-    echo "# Credits:                                                                    #"
-    echo "#   The Box86 team (ptitSeb, pale, chills340, Itai-Nelken, Heasterian, et al) #"
-    echo "#   Esme 'madewokherd' Povirk (CodeWeavers) for wine-mono debugging/support   #"
-    echo "#   N7ACW, AD7HE, & KK6FVG for getting me started in ham radio                #"
-    echo "#   K6ETA & DCJ21's Winlink on Linux guides                                   #"
-    echo "#   KM4ACK & OH8STN for inspiration                                           #"
-    echo "#                                                                             #"
-    echo "#    \"My humanity is bound up in yours, for we can only be human together\"    #"
-    echo "#                                                - Nelson Mandela             #"
-    echo "#                                                                             #"
-    echo "# If you like this project please consider donating to Sebastien Chevalier    #"
-    echo "#   (the creator of box86) or CodeWeavers (wine, wine-mono).                  #"
-    echo "#                                                                             #"
-    echo "#                  - Donate to Box86:  paypal.me/0ptitSeb -                   #"
-    echo "#    - Support Esme & CodeWeavers: https://www.codeweavers.com/crossover -    #"
-    echo "#       - Donate to Wine / wine-mono:  https://www.winehq.org/donate -        #"
-    echo "###############################################################################"
-}
+# TODO: Check for exe's after each install. Error if no exe present.
+# TODO: Add timeout timer for VARA settings menu in case of freeze. Then do `wineserver -k` if needed
+# TODO: Add bap switch to run_giveup
+# TODO: Compile newer custom 32-bit RPiOS kernel for RPi3 and host it.
 
 # About:
 #    This script will help you install Box86, Wine, winetricks, Windows DLL's, Winlink (RMS Express) & VARA.  You will then
@@ -35,27 +14,21 @@ function run_greeting()
 #    To run Windows .exe files on RPi4, we need an x86 emulator (box86) and a Windows API Call interpreter (wine).
 #    Box86 is opensource and runs about 10x faster than ExaGear or Qemu.  It's much smaller and easier to install too.
 #
-#    This installer should take about 10 minutes on a Raspberry Pi 4B.
-#
 # Distribution:
-#    This script is free to use, open-source, and should not be monetized.  If you use this script in your project (or are inspired by it) just please be sure to mention ptitSeb, Box86, and myself (KI7POL).
+#    This script is free to use, open-source, and should not be monetized.  If you use this script in your project (or are 
+#    inspired by it) just please be sure to mention ptitSeb, Box86, and myself (KI7POL).
 #
 # Legal:
-#    All software used by this script is free and legal to use (with the exception of VARA, of course, which is shareware).  Box86 and Wine are both open-source (which avoids the legal problems of use & distribution that ExaGear had - ExaGear also ran much slower than Box86 and is no-longer maintained, despite what Huawei says these days).  All proprietary Windows DLL files required by Wine are downloaded directly from Microsoft and installed according to their redistribution guidelines.
-#
-# Known bugs:
-#    If programs freeze, use 'wineserver -k' to restart wine.
-#    The Channel Selector is functional, it just takes about 5 minutes to update its propagation indices and sometimes crashes the first time it's loaded.  Just restart it if it crashes.  If you let it run for 5 minutes, then you shouldn't have to do that again - just don't hit the Update Table Via Internet button.  I'm currently experimenting with ITS HF: http://www.greg-hand.com/hfwin32.html
-#    VARA has some graphics issues if we leave window control on in Wine.  Leaving window control on in Wine is a good idea for RPi4 since it reduces CPU overhead.
-#
-# Donations:
-#    If you feel that you are able and would like to support this project, please consider sending donations to ptitSeb or KM4ACK - without whom, this script would not exist.
-#        - Sebastien "ptitSeb" Chevalier - author of "Box86": paypal.me/0ptitSeb
-#        - Jason Oleham (KM4ACK) - inspiration & Linux elmer: paypal.me/km4ack
+#    All software used by this script is free and legal to use (with the exception of VARA, of course, which is shareware).
+#    Box86 and Wine are both open-source (which avoids the legal problems of use & distribution that ExaGear had - ExaGear 
+#    also ran much slower than Box86 and is no-longer maintained, despite what Huawei says these days).  All proprietary 
+#    Windows DLL files required by Wine are downloaded directly from Microsoft and installed according to their redistribution 
+#    guidelines.
 #
 # Code overview:
-#    This script has a main routine that runs subroutines.  Not all subroutines in this script are used - some are just for testing purposes.
-#    This script just works for Raspberry Pi 4B at the moment, but I hope to one day have it detect CPU, OS, and distro, and install accordingly.
+#    This script has a main routine that runs subroutines.  Some subroutines in this script are not used and are just for testing.
+#    This script is designed for Raspberry Pi 4B, but the hope is to get it running on more systems (x86/x64 Linux, RPi3, etc.)
+#    If you're reading this, I apologize for the confusing layout of this code.  I hope to make it cleaner one day.
 #
 
 
@@ -63,6 +36,10 @@ function run_main()
 {
     export WINEDEBUG=-all # silence winedbg for this instance of the terminal
     local ARG="$1" # store the first argument passed to the script file as a variable here (i.e. 'bash install_winelink.sh vara_only')
+
+    ### Pre-installation
+    run_checkpermissions
+    run_checkxhost
     
     ### Clean up previous runs (or failed runs) of this script
         sudo rm install_winelink.sh 2>/dev/null # silently remove this script so it cannot be re-run by accident
@@ -70,39 +47,242 @@ function run_main()
         sudo rm ${STARTMENU}/winlinkexpress.desktop ${STARTMENU}/vara.desktop ${STARTMENU}/vara-fm.desktop \
                 ${STARTMENU}/vara-sat.desktop ${STARTMENU}/vara-chat.desktop ${STARTMENU}/vara-soundcardsetup.desktop \
                 ${STARTMENU}/vara-update.desktop ${STARTMENU}/resetwine.desktop 2>/dev/null # remove old shortcuts
+	rm ${HOME}/RMS\ Express\ *.log 2>/dev/null # silently remove old RMS Express logs
 		 
         
     ### Create winelink directory
         mkdir ${HOME}/winelink && cd ${HOME}/winelink # store all downloaded/installed files in their own directory
     
-        ### Pre-installation
-            exec > >(tee "winelink.log") 2>&1 # start logging
-            run_checkpermissions
-            run_checkxhost
-            run_gather_os_info
-            #run_detect_arch # TODO: Customize this section to install wine for different operating systems.
-            
-            # Greet the user
-            run_greeting
-            if [ "$ARG" = "bap" ]; then
-                sleep 10 # If using Build-a-Pi (if 'bap' was passed to the script) then let greeting run without user intervention.
-		echo "Install will begin in 10 seconds"
-            else
-                read -n 1 -s -r -p "Press any key to continue . . ."
-            fi
-            clear
-            
-        ### Install Wine, winetricks, autohotkey, and box86
-            run_installwine "pi4" "devel" "7.1" "debian" "${VERSION_CODENAME}" "-1" # windows API-call interperter for non-windows OS's - freeze version to ensure compatability
+        ### Start logging
+        exec > >(tee "winelink.log") 2>&1
+        
+	### Wine omni-installation
+	########################################################################################################################################
+	# Installation of Wine is CPU/OS-specific. But after Wine is installed, program installation steps within Wine are universal.          #
+	# - Feel free to add your Wine install for your hardware/software setup here to make this script work on your computer.                #
+	# - Readability & maintenance of this section is preferred over code elegance, so this section is a little long & redundant in places. #
+	# - Nested case statements: https://unix.stackexchange.com/questions/15216/bash-nested-case-syntax-and-terminators                     #
+	run_detect_arch
+	run_detect_os  # os-release file vars by OS: https://docs.google.com/spreadsheets/d/1ixz0PfeWJ-n8eshMQN0BVoFAFnUmfI5HIMyBA0uK43o/edit#gid=0
+
+	case $ARCH in
+	"ARM32"|"ARM64") ############### armhf & aarch64 OS Section ###############
+		run_detect_rpi
+		case $PI_SERIES in # Check for Pi's that can run in 64-bit ARM ( https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-64-bit )
+		"Pi4")
+			case $ID in
+			"raspbian"|"debian") # Pi4 with Raspberry Pi OS
+				case $ARCH in # determine 32-bit or 64-bit RPiOS
+				"ARM32")
+					run_greeting "${PI_SERIES} ${ARCH} " " 8" "2.1" "${ARG}" #Vars: "Hardware", "OS Bits", "Minutes", "GB", "bap" (check if user passed "bap" to script)
+					run_checkdiskspace "2100" #min space required in MB
+					run_downloadbox86 "ed8e01ea_RPI4" #emulator to run i386-wine on ARM32 (freeze version at ed8e01ea, which runs RMS, VARAHF/FM, and TCP works)
+					#run_buildbox86 "ed8e01ea0c69739ced597fecb5c3d61b96c5c761" "RPI4" "ARM64" #TODO: Double-check this (arm32 better for building?) # NOTE: RPI3 and RPI3ARM64 don't build on Pi3B+ (`cc: error: unrecognized command-line option ‘-marm’`) but RPI4ARM64 does.
+					run_sideloadi386wine "devel" "7.1" "debian" "${VERSION_CODENAME}" "-1"
+					;; #/"ARM32")
+				"ARM64")
+					run_greeting "${PI_SERIES} ${ARCH} " "10" "2.8" "${ARG}"
+					run_checkdiskspace "2800" #min space required in MB
+					run_downloadbox86 "ed8e01ea_RPI4"
+					#run_buildbox86 "ed8e01ea0c69739ced597fecb5c3d61b96c5c761" "RPI4" "ARM64"
+					run_sideloadi386wine "devel" "7.1" "debian" "${VERSION_CODENAME}" "-1"
+					run_install64bitRpiOSi386WineDependencies
+					;; #/"ARM64")
+				esac #/case $ARCH
+				;; #/"raspbian"|"debian")
+			*)
+				echo -e "ERROR: For Raspberry Pi's, only RPiOS is supported by Winelink at this time.\nGiving up on install."
+				run_giveup
+				;; #/*)
+			esac #/case $ID
+			;; #/"Pi4")
+		"Pi3+"|"Pi3")
+			case $ID in
+			"raspbian"|"debian") # Pi3 with Raspberry Pi OS (64-bit)...
+				case $ARCH in
+				"ARM32")
+					run_greeting "${PI_SERIES} ${ARCH}" "35" "4.1" "${ARG}"
+					#ARG="bap" # Force-skip RMS Express installation (since it doesn't run great on RPi3B+)
+					run_checkdiskspace "4100" #min space required in MB
+					run_increasepi3swapfile # Helps prevent insufficient RAM crashes when building box86
+					run_custompi3kernel "1" # This kernel installer will ignore 64bit Pi3's since they already have 3G/1G VMem Swap (not needed for 64-bit RPiOS)
+					run_downloadbox86 "ed8e01ea_RPI4"
+					#run_buildbox86 "ed8e01ea0c69739ced597fecb5c3d61b96c5c761" "RPI4" "ARM64" #TODO: Double-check this (arm32 better for building?) # NOTE: RPI3 and RPI3ARM64 don't build on Pi3B+ (`cc: error: unrecognized command-line option ‘-marm’`) but RPI4ARM64 does.
+					run_sideloadi386wine "devel" "7.1" "debian" "${VERSION_CODENAME}" "-1"
+					;; #"ARM32")
+				"ARM64")
+					run_greeting "${PI_SERIES} ${ARCH}" "28" "3.5" "${ARG}"
+					#ARG="bap" # Force-skip RMS Express installation (since it doesn't run great on RPi3B+)
+					run_checkdiskspace "3500" #min space required in MB
+					run_increasepi3swapfile # Helps prevent insufficient RAM crashes when building box86
+					run_downloadbox86 "ed8e01ea_RPI4"
+					#run_buildbox86 "ed8e01ea0c69739ced597fecb5c3d61b96c5c761" "RPI4" "ARM64"
+					run_sideloadi386wine "devel" "7.1" "debian" "${VERSION_CODENAME}" "-1"
+					run_install64bitRpiOSi386WineDependencies
+					;; #"ARM64")
+				esac #/case $ARCH
+				;; #/"raspbian"|"debian")
+			*)
+				echo -e "ERROR: For Raspberry Pi's, only RPiOS is supported by Winelink at this time.\nGiving up on install."
+				run_giveup
+				;; #/*)
+			esac #/case $ID
+			;; #/"Pi3+"|"Pi3")
+		"PiZ2") # TODO - Get a PiZ2W and test this
+			#run_custompi3kernel "1" 
+			#run_installwine "piz2" "devel" "7.1" "${ID_LIKE}" "${VERSION_CODENAME}" "-1"
+			echo -e "ERROR: Raspberry Pi Zero 2W is not supported yet, but might be in the future.\nGiving up on install."
+			run_giveup
+			;; #/"PiZ2")
+		#"") #TODO: Enable this when Termux install available
+		#	: # If no Pi variable is set, do nothing and continue on to check for other hardware cases.
+		#	;; #/"")
+		*)
+			echo "Your Raspberry Pi is too old to work well with wine/box86 emulation."
+			echo "Giving up on install."
+			run_giveup
+			;; #/*)
+		esac #/case $PI_SERIES
+
+		# case $FOUNDTERMUX in # TODO - Check for 64-bit Termux
+		# "Termux")
+		#	run_AnBox?
+		#	;; #/"Termux")
+		#"")
+		#	: # If no Termux variable is set, do nothing and continue on to check for other hardware cases.
+		#	;; #/"")
+		# esac
+		#
+		# TODO - If Pi or Termux is not found, what happens then?
+
+		;; #/ARM64|ARM32)
+
+	"x86"|"x64") ############### i386 & i686 OS Section ###############
+		case $ID in
+		"debian"|"raspbian")
+			run_greeting "${ARCH}" "30" "1.5" "${ARG}"
+			run_checkdiskspace "1500" #min space required in MB
+			
+			# TODO: Use the OS-specific package manager to install needed packages? Or do a 'try' in-situ?
+			#sudo apt-get install wget p7zip-full cabextract curl megatools zenity -y
+
+			#Make sure system time and certs are up to date (in case system is old or a virtual machine).
+			#Also, if NTP is not installed, install it.
+			ntpq --help &> /dev/null || NTPCHECK="no_ntp" # if an error returns from the command 'ntpq --help' then set NTPCHECK to "no_ntp"
+			if [ "$NTPCHECK" = "no_ntp" ]; then # If ntp time management package doesn't exist, install/configure it
+				sudo apt-get install ntp ntpdate -y
+				sudo sed -i 's$#server ntp.your-provider.example$server 10.1.1.1 prefer iburst$g' /etc/ntp.conf
+			fi
+			sudo systemctl stop ntp
+			sudo ntpd -gq
+			sudo systemctl start ntp
+			#sudo apt-get update && apt-get upgrade -y
+			sudo update-ca-certificates -v
+
+			#Install wine (note: packages are called "wine-stable", not "winehq-stable" like in the Wine wiki).
+			sudo dpkg --add-architecture i386 # also install wine32 using multi-arch
+			sudo apt-key del "D43F 6401 4536 9C51 D786 DDEA 76F1 A20F F987 672F" #apt-key is deprecated, but this step is here as a hotfix in case distro has an old winehq gpg key installed
+			sudo wget -O /usr/share/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key || { echo "unable to download winehq gpg key!" && run_giveup; }
+			sudo wget -P /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/${VERSION_CODENAME}/winehq-${VERSION_CODENAME}.sources || { echo "unable to download winehq sources file!" && run_giveup; }
+			sudo sed -i 's&/etc/apt/keyrings/winehq-archive.key&/usr/share/keyrings/winehq-archive.key&g' /etc/apt/sources.list.d/winehq-${VERSION_CODENAME}.sources #fix bug found in the winehq-bullseye.sources file present 09/11/2022
+				#Note: Old method for installing key and repo
+				#wget -O - https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add -
+				#sudo add-apt-repository "deb https://dl.winehq.org/wine-builds/debian/ ${VERSION_CODENAME} main"
+			sudo apt-get update -y
+			sudo apt-get install --install-recommends wine-stable winehq-stable -y || { echo "wine instllation failed!" && run_giveup; } #note: winehq-stable is required for debian or else no symlinks will be made in /usr/local/bin/
+				#Note: Method for installing old versions of wine
+				#sudo apt-get install --install-recommends wine-${branch}-amd64=${version}~${dist} --allow-downgrades -y # Allow downgrades so that we can install old versions of wine if desired
+				#sudo apt-get install --install-recommends wine-${branch}-i386=${version}~${dist} wine-${branch}=${version}~${dist} winehq-${branch}=${version}~${dist} --allow-downgrades -y
+
+			#Add the user to the USB dialout group so that they can access radio USB CAT control later.
+			sudo usermod -a -G dialout $USER
+			#sudo reboot # In Ubuntu, "logout/login doesn't work. we have to reboot after doing usermod."
+
+			#Figure out which wine com port to connect RMS Express to in order to get CAT control.
+				#sudo dmesg | grep tty # see if radio USB port is connected to computer (via one of the ttyUSB ports)
+				#ls -l ~/.wine/dosdevices/com* # see if wine is connected to radio USB port (via one of its fake com ports)
+				#Debian 11 & RPiOS (wine-stable ): com5
+				#Linux Mint (wine-devel ): com33
+
+			echo "Installation for this distro is in alpha status."
+			echo "Reboot after installation is required for CAT control"
+			echo "Please report issues to: https://github.com/WheezyE/Winelink/issues"
+			echo ""
+		;; #/"debian"|"raspbian")
+		"ubuntu"|"linuxmint") #TODO: TEST THESE
+			case $ARCH in
+			"x86") # i386 OS
+				echo "No install path has been scouted for this distro yet."
+				echo "Please post a request on the Winelink Github Issues page:"
+				echo "https://github.com/WheezyE/Winelink/issues"
+				echo ""
+				echo "Giving up on installation"
+				run_giveup
+				;; #/x86)
+			"x64")
+				run_greeting "${ARCH}" "30" "1.5" "${ARG}"
+				run_checkdiskspace "1500" #min space required in MB
+
+				#Make sure system time and certs are up to date (in case system is old or a virtual machine)
+				sudo service ntp stop
+				sudo ntpd -gq
+				sudo service ntp start
+				sudo update-ca-certificates -v
+
+				#Install wine (note: In Ubuntu, packages are called "wine-stable", not "winehq-stable" like in the Wine wiki).
+				sudo dpkg --add-architecture i386 #Install procedure last reviewed 09/07/2022 - ejw
+				sudo wget -O /usr/share/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key || { echo "unable to download winehq gpg key!" && run_giveup; }
+				sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/${UBUNTU_CODENAME}/winehq-${UBUNTU_CODENAME}.sources || { echo "unable to download winehq sources file!" && run_giveup; }
+				sudo apt-get update
+				#sudo apt-get install --install-recommends wine-stable -y  || { echo "wine instllation failed!" && run_giveup; } #note: no winehq-stable package for ubuntu. Symlinks are still created though#sudo apt-get install --install-recommends wine-stable -y  || { echo "wine instllation failed!" && run_giveup; } #note: no winehq-stable package for ubuntu. Symlinks are still created though
+				sudo apt-get install --install-recommends winehq-devel -y  || { echo "wine instllation failed!" && run_giveup; } #note: for some reason wine-stable lags far behind on ubuntu
+
+				#Add the user to the USB dialout group so that they can access radio USB CAT control later.
+				sudo usermod -a -G dialout $USER
+				#sudo reboot # In Ubuntu, "logout/login doesn't work. we have to reboot after doing usermod."
+
+				#Figure out which wine com port to connect RMS Express to in order to get CAT control.
+				#sudo dmesg | grep tty # see if radio USB port is connected to computer (via one of the ttyUSB ports)
+				#ls -l ~/.wine/dosdevices/com* # see if wine is connected to radio USB port (via one of its fake com ports)
+				#Debian 11 & RPiOS (wine-stable ): com5
+				#Linux Mint (wine-devel ): com33
+
+				# TODO: VARA Settings freeze the installer. Consider adding a countdown timer that runs wineserver -k after 10s if no progress? x2
+				echo "Installation for this distro is in alpha status."
+				echo "Reboot after installation is required for CAT control"
+				echo "Please report issues to: https://github.com/WheezyE/Winelink/issues"
+				echo ""
+				;; #/x64)
+			esac #/case $ARCH
+			;; #/"ubuntu"|"linuxmint")
+		*)
+			echo "No install path has been scouted for this distro yet."
+			echo "Please post a request on the Winelink Github Issues page:"
+			echo "https://github.com/WheezyE/Winelink/issues"
+			echo ""
+			echo "Giving up on installation"
+			run_giveup
+			;; #/*)
+		esac #/case $ID
+		;; #/"x86"|"x64")
+	*)
+		echo "Something went wrong with system architecture identification. Giving up."
+		run_giveup
+		;; #/*)
+	esac #/case $ARCH
+	#                                                                                                                                      #
+	# The script should be universal (not CPU/OS-specific) from this point on.                                                             #
+	########################################################################################################################################
+		
+        ### Install winetricks & autohotkey - TODO: Add wget & package manager detection
             run_installwinetricks # software installer script for wine
             run_installahk
-            run_downloadbox86 10_Dec_21 # emulator to run wine-i386 on ARM - freeze version to ensure compatability
         
         ### Set up Wine (silently make & configure a new wineprefix)
             run_setupwineprefix $ARG # if 'vara_only' was passed to the winelink script, then pass 'vara_only' to this subroutine function too
 	
         ### Install Winlink & VARA into our configured wineprefix
-            if [ "$ARG" = "vara_only" ] || [ "$ARG" = "bap" ]; then
+            if [ "$ARG" = "vara_only" ] || [ "$ARG" = "bap" ]; then #TODO: Am I using brackets and ='s correctly?
                 run_installvara
             else
                 run_installrms
@@ -118,12 +298,21 @@ function run_main()
                 run_varasoundcardsetup
             fi
 	    run_makeuninstallscript
+	    
             clear
-            echo -e "\n${GREENTXT}Setup complete.${NORMTXT}\n"
+            echo -e "\n${GREENTXT}Setup complete.${NORMTXT}"
+            case $ARCH in
+                "x86"|"x64")
+                    echo -e "\n${GREENTXT}Rebooting is recommended for CAT control (not needed for RPiOS)${NORMTXT}" #TODO: Add a guide on how to find USB CAT ports.
+                    ;; #/"x86"|"x64")
+		*)
+		    : #do nothing
+		    ;; #/*)
+            esac #/case $ARCH
 	    
 	    # cleanup
-	    rm -rf ${HOME}/winelink/downloads
-	    rm ${HOME}/winelink/winelink.log
+	    rm -rf ${HOME}/winelink/downloads 2>/dev/null # silently remove Winlink downloads directory
+	    rm ${HOME}/winelink/winelink.log 2>/dev/null # silently remove old RMS Express logs
         cd ..
     exit
 }
@@ -133,6 +322,43 @@ function run_main()
 
 ############################################# Subroutines #############################################
 
+function run_greeting()
+{
+    local hardware="$1"
+    local tinst="$2"
+    local space="$3"
+    local arg="$4"
+    
+    clear
+    echo ""
+    echo "####################### Winlink & VARA Installer Script #######################"
+    echo "# Author: Eric Wiessner (KI7POL)                          System: ${hardware}  #"
+    echo "# Version: 0.0097a                                  Install time: apx ${tinst} min  #"
+    echo "#                                                 Space required: apx ${space} GB  #"
+    echo "# Credits:                                                                    #"
+    echo "#   The Box86 team (ptitSeb, pale, chills340, Itai-Nelken, Heasterian, et al) #"
+    echo "#   Esme 'madewokherd' Povirk (CodeWeavers) for adding functions to wine-mono #"
+    echo "#   Botspot for RPi kernel switching bash code. Chris Keller for Pat support. #"
+    echo "#   N7ACW, AD7HE, & KK6FVG for getting me started in ham radio.               #"
+    echo "#   KM4ACK & OH8STN for inspiration. K6ETA & DCJ21's Winlink on Linux guides. #"
+    echo "#                                                                             #"
+    echo "# Donations:                                                                  #"
+    echo "#    Box86                        paypal.me/0ptitSeb                          #"
+    echo "#    madewokherd / CodeWeavers    codeweavers.com/crossover                   #"
+    echo "#    Wine / wine-mono             winehq.org/donate                           #"
+    echo "#                                                                             #"
+    echo "#    \"My humanity is bound up in yours, for we can only be human together\"    #"
+    echo "#                                                - Nelson Mandela             #"
+    echo "###############################################################################"
+    
+    if [ "$arg" = "bap" ]; then
+    	echo "Install will begin in 10 seconds"
+	sleep 10 # If using Build-a-Pi (if 'bap' was passed to the script) then let greeting run without user intervention.
+    else
+	read -n 1 -s -r -p "Press any key to continue . . ."
+    fi
+    clear
+}
 
 function run_checkpermissions()  # Ensure that script is not run as root & that user account has sudo permissions
 {
@@ -145,7 +371,11 @@ function run_checkpermissions()  # Ensure that script is not run as root & that 
     # If user cannot run sudo commands, then exit (since we have lots of sudo commands in this script)
     sudo -l &> /dev/null || SUDOCHECK="no_sudo" # if an error returns from the command 'sudo -l' then set SUDOCHECK to "no_sudo"
     if [ "$SUDOCHECK" = "no_sudo" ]; then
-        echo -e "\n${GREENTXT}Please give your user account sudoer access before running this script.${NORMTXT}\n"
+        echo -e "${GREENTXT}Please give your user account sudoer access before running this script.${NORMTXT}"
+	echo -e "${GREENTXT}You can do this by copy-pasting the following commands ONE LINE AT A TIME:${NORMTXT}"
+	echo "    su - #enter root, then copy-paste these next commands into root"
+	echo '    echo "'"${USER} ALL=(ALL) NOPASSWD: ALL"'" >> /etc/sudoers'
+	echo "    exit #log out of root"
         run_giveup
     fi
 }
@@ -158,101 +388,359 @@ function run_checkxhost()  # Check to see if an xserver is running (ie are we in
     fi
 }
 
-function run_downloadbox86()  # Download & install Box86. (This function needs a date passed to it)
+function run_checkdiskspace()
+{
+	# https://stackoverflow.com/questions/41127585/shell-how-to-check-available-space-and-exit-if-not-enough
+	# https://unix.stackexchange.com/questions/179274/what-does-1k-blocks-column-mean-in-the-output-of-df
+	# Byte conversions https://docs.google.com/spreadsheets/d/13c4mXAcKSfo5qoa6zvWUhWv9rkL0A-fefuh3fiicON0/edit?usp=sharing
+	
+	local reqSpaceMB=$1 # Note: Input values should be in MB (aka 1000 kB per MB; 1000 bytes per kB), not in MiB (1024 KiB per MiB).
+	reqSpace512Blocks=$(($reqSpaceMB*1000000/512))  # Convert MB to 512-byte units for POSIX calculation below (POSIX 1 block = 512 bytes)
+							# y 512Blocks = x MB * (1000000 bytes / 1 MB) * (1 512Block / 512 bytes)
+	
+	availSpace=$(POSIXLY_CORRECT=1 df "$HOME" | awk 'NR==2 { print $4 }') # A "1" value = 512 bytes in this POSIX notation
+	if (( availSpace < reqSpace512Blocks )); then
+		echo "Winelink requires at least $reqSpaceMB MB of disk space." >&2
+		echo "Please free up more space or use a larger SD card, then try again."
+		run_giveup
+	fi
+}
+
+function run_downloadbox86()  # Download & install Box86. (This function needs a date passed to it) - TODO: Replace with self-hosted github binaries
 {
     sudo apt-get install p7zip-full -y # TODO: remove redundant apt-get installs - put them at top of script.
-    local date="$1"
+    local version="$1"
     
-    echo -e "\n${GREENTXT}Downloading and installing Box86 . . .${NORMTXT}\n"
+    echo -e "${GREENTXT}Downloading and installing Box86 . . .${NORMTXT}"
     mkdir downloads 2>/dev/null; cd downloads
         mkdir box86; cd box86
             sudo rm /usr/local/bin/box86 2>/dev/null # in case box86 is already installed and running
-            wget -q https://archive.org/download/box86.7z_20200928/box86_"$date".7z || { echo "box86_$date download failed! Please check your internet connection and re-run the script." && run_giveup; }
-            7z x box86_"$date".7z -y -bsp0 -bso0
-            sudo cp box86_"$date"/build/system/box86.conf /etc/binfmt.d/
-            sudo cp box86_"$date"/build/box86 /usr/local/bin/box86
-            sudo cp box86_"$date"/x86lib/* /usr/lib/i386-linux-gnu/
+            wget -q https://github.com/WheezyE/Winelink/raw/WheezyE-patch-5/binaries/box86_"$version".7z # || { echo "box86_$version download failed!" && run_giveup; }
+            wget -q https://github.com/WheezyE/Winelink/raw/main/binaries/box86_"$version".7z # || { echo "box86_$version download failed!" && run_giveup; }
+	    7z x box86_"$version".7z -y -bsp0 -bso0
+            sudo cp box86_"$version"/build/system/box86.conf /etc/binfmt.d/
+            sudo cp box86_"$version"/build/box86 /usr/local/bin/box86
+	    sudo chmod +x /usr/local/bin/box86
+	    sudo mkdir /usr/lib/i386-linux-gnu/ 2>/dev/null;
+            sudo cp box86_"$version"/x86lib/* /usr/lib/i386-linux-gnu/
             sudo systemctl restart systemd-binfmt # must be run after first installation of box86 (initializes binfmt configs so any encountered i386 binaries are sent to box86)
         cd ..
     cd ..
 }
 
-function run_buildbox86()  # Build & install Box86. (This function needs a commit hash passed to it)
+function run_buildbox64() # This method is not currently used
 {
-    sudo apt-get install cmake git -y
-    local commit="$1"
+    # This function can only be run on a 64-bit ARM OS (32-bit will fail)
+    local commit86="$1"
+    local series="$2" # "RPI4"
     
-    echo -e "\n${GREENTXT}Building and installing Box86 . . .${NORMTXT}\n"
+    # Build and install box64
+    sudo apt install git cmake python3 build-essential gcc -y # box64 dependencies
+    echo -e "${GREENTXT}Building and installing Box64 . . .${NORMTXT}"
     mkdir downloads 2>/dev/null; cd downloads
-        mkdir box86; cd box86
-            rm -rf box86-builder; mkdir box86-builder && cd box86-builder/
-                git clone https://github.com/ptitSeb/box86 && cd box86/
-                    git checkout "$commit"
+        mkdir box64; cd box64
+            rm -rf box64-builder; mkdir box64-builder && cd box64-builder/
+                git clone https://github.com/ptitSeb/box64 && cd box64
+                    git checkout "$commit64"
                     mkdir build; cd build
-                        cmake .. -DRPI4=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-                        make #-j4 may cause crashes in some builds of box86 due to high cpu load
-                        sudo make install # copies box86 files into their directories (/usr/local/bin/box86, /usr/lib/i386-linux-gnu/, /etc/binfmt.d/)
-                        sudo systemctl restart systemd-binfmt # must be run after first installation of box86 (initializes binfmt configs so any encountered i386 binaries are sent to box86)
+                        cmake .. -DARM_DYNAREC=ON -D${series}ARM64=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+			make -j$(($(nproc)-2)) # compile using all processors minus one (to prevent OS freezes)
+                        sudo make install
+                        sudo systemctl restart systemd-binfmt
                     cd ..
                 cd ..
             cd ..
         cd ..
     cd ..
 }
+
+function run_buildbox86() # Compile box64 & box86 on-device (takes a long time, builds are fresh and links less breakable)
+{
+    # This function can only be run on an ARM OS (32-bit or 64-bit)
+    local commit86="$1" # "ed8e01ea0c69739ced597fecb5c3d61b96c5c761"
+    local series="$2" # "RPI4"
+    local arch="$3" # "ARM64" (ARM32 is not needed since it's default)
+	
+    # Build and install box86
+    sudo apt-get install cmake git -y # box86 dependencies
+
+    if [ "$arch" == "ARM64" ]; then
+        sudo apt-get install gcc-arm-linux-gnueabihf python3 build-essential gcc -y # extra box86 dependencies for aarch64
+    elif [ "$arch" == "ARM32" ]; then
+        local arch="" # box86 builds ARM32 by default
+    fi
+
+    echo -e "${GREENTXT}Building and installing Box86 . . .${NORMTXT}"
+    mkdir downloads 2>/dev/null; cd downloads
+        mkdir box86; cd box86
+            rm -rf box86-builder; mkdir box86-builder && cd box86-builder/
+                git clone https://github.com/ptitSeb/box86 && cd box86/
+                    git checkout "$commit86"
+                    mkdir build; cd build
+                        cmake .. -DARM_DYNAREC=ON -D${series}${arch}=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+			if [ "$(nproc)" > 1 ]; then
+                        	make -j$(($(nproc)-1)) # compile using all processors minus one (to prevent OS freezes)
+			else
+				make
+			fi
+                        sudo make install
+                        sudo systemctl restart systemd-binfmt
+                    cd ..
+                cd ..
+            cd ..
+        cd ..
+    cd ..
+}
+
+function run_sideloadi386wine() {
+	# NOTE: We only need i386-wine/box86 on RPi (regardless of 64-bit or 32-bit RPiOS)
+	# We don't need amd64-wine64/box64 for our purposes of running RMS Express and VARA.
+
+	# Wine version variables
+	local branch="$1" #example: "devel" or "stable" without quotes (wine-staging 4.5+ depends on libfaudio0 and requires more install steps)
+	local version="$2" #example: "7.1"
+	local id="$3" #example: debian ($ID_LIKE) - TODO: implement other distros, like Ubuntu
+	local dist="$4" #example: bullseye ($VERSION_CODENAME)
+	local tag="$5" #example: -1
+
+	# Clean up any old wine instances
+	wineserver -k &> /dev/null # stop any old wine installations from running - TODO: double-check this command
+	rm -rf ~/.cache/wine # remove any old wine-mono or wine-gecko install files in case wine was installed previously
+	rm -rf ~/.local/share/applications/wine # remove any old program shortcuts
+
+	# Backup any old wine installs
+	rm -rf ~/wine-old 2>/dev/null; mv ~/wine ~/wine-old 2>/dev/null
+	rm -rf ~/.wine-old 2>/dev/null; mv ~/.wine ~/.wine-old 2>/dev/null
+	sudo mv /usr/local/bin/wine /usr/local/bin/wine-old 2>/dev/null
+	sudo mv /usr/local/bin/wineboot /usr/local/bin/wineboot-old 2>/dev/null
+	sudo mv /usr/local/bin/winecfg /usr/local/bin/winecfg-old 2>/dev/null
+	sudo mv /usr/local/bin/wineserver /usr/local/bin/wineserver-old 2>/dev/null
+
+	# Wine download links from WineHQ: https://dl.winehq.org/wine-builds/
+	#LNKA="https://dl.winehq.org/wine-builds/${id}/dists/${dist}/main/binary-amd64/" #amd64-wine links
+	#DEB_A1="wine-${branch}-amd64_${version}~${dist}${tag}_amd64.deb" #wine64 main bin
+	#DEB_A2="wine-${branch}_${version}~${dist}${tag}_amd64.deb" #wine64 support files (required for wine64 / can work alongside wine_i386 main bin)
+		#DEB_A3="winehq-${branch}_${version}~${dist}${tag}_amd64.deb" #shortcuts & docs?
+	LNKB="https://dl.winehq.org/wine-builds/${id}/dists/${dist}/main/binary-i386/" #i386-wine links
+	DEB_B1="wine-${branch}-i386_${version}~${dist}${tag}_i386.deb" #wine_i386 main bin
+	DEB_B2="wine-${branch}_${version}~${dist}${tag}_i386.deb" #wine_i386 support files (required for wine_i386 if no wine64 / CONFLICTS WITH wine64 support files)
+		#DEB_B3="winehq-${branch}_${version}~${dist}${tag}_i386.deb" #shortcuts & docs?
+
+	# Download, extract wine, and install wine
+	mkdir downloads 2>/dev/null; cd downloads
+		echo -e "${GREENTXT}Downloading wine . . .${NORMTXT}" # Install i386-wine (32-bit)
+		wget -q ${LNKB}${DEB_B1} || { echo "${DEB_B1} download failed!" && run_giveup; }
+		wget -q ${LNKB}${DEB_B2} || { echo "${DEB_B2} download failed!" && run_giveup; }
+		echo -e "${GREENTXT}Extracting wine . . .${NORMTXT}"
+		dpkg-deb -x ${DEB_B1} wine-installer
+		dpkg-deb -x ${DEB_B2} wine-installer
+		echo -e "${GREENTXT}Installing wine . . .${NORMTXT}\n"
+		mv wine-installer/opt/wine* ~/wine
+		
+		## Old codescrap: Install amd64-wine (64-bit) and i386-wine (32-bit)
+		#echo -e "\n${GREENTXT}Downloading wine . . .${NORMTXT}"
+		#wget -q ${LNKA}${DEB_A1} || { echo "${DEB_A1} download failed!" && run_giveup; }
+		#wget -q ${LNKA}${DEB_A2} || { echo "${DEB_A2} download failed!" && run_giveup; }
+		#wget -q ${LNKB}${DEB_B1} || { echo "${DEB_B1} download failed!" && run_giveup; }
+		#echo -e "${GREENTXT}Extracting wine . . .${NORMTXT}"
+		#dpkg-deb -x ${DEB_A1} wine-installer
+		#dpkg-deb -x ${DEB_A2} wine-installer
+		#dpkg-deb -x ${DEB_B1} wine-installer
+		#echo -e "${GREENTXT}Installing wine . . .${NORMTXT}\n"
+		#mv wine-installer/opt/wine* ~/wine	
+	cd ..
+
+	# Install symlinks (and make 32bit launcher. Credits: grayduck, Botspot) - TODO: Try to remove linux32 flag
+	echo -e '#!/bin/bash\nsetarch linux32 -L '"$HOME/wine/bin/wine "'"$@"' | sudo tee -a /usr/local/bin/wine >/dev/null # script to launch wine programs as 32bit only
+	#sudo ln -s ~/wine/bin/wine /usr/local/bin/wine # you could also just make a symlink, but box86 only works for 32bit apps at the moment
+	sudo ln -s ~/wine/bin/wineboot /usr/local/bin/wineboot
+	sudo ln -s ~/wine/bin/winecfg /usr/local/bin/winecfg
+	sudo ln -s ~/wine/bin/wineserver /usr/local/bin/wineserver
+	sudo chmod +x /usr/local/bin/wine /usr/local/bin/wineboot /usr/local/bin/winecfg /usr/local/bin/wineserver
+}
+
+function run_install64bitRpiOSi386WineDependencies()
+{
+	# Install 64-bit RPiOS i386-Wine dependencies for (also for Ubuntu 64-bit)
+	#    libc6:armhf is needed for box86 to be detected by aarch64 https://github.com/ptitSeb/box86/issues/465
+	#    Unsure about the rest but wine-amd64 & wine-i386 on aarch64 need some libs too.
+	#    Credits: monkaBlyat (Dr. van RockPi), Itai-Nelken, & WheezyE
+	#    TODO: Go through this dependencies list and weed out un-needed libraries.
+	echo -e "${GREENTXT}Installing armhf dependencies for i386-Wine on aarch64 . . .${NORMTXT}"
+	sudo dpkg --add-architecture armhf && sudo apt update #enable multi-arch on aarch64 (so we can install armhf libraries for box86/winei386)
+	sudo apt-get install apt-utils libcups2 libfontconfig1 libncurses6 libxcomposite-dev libxcursor-dev libxi6 libxinerama1 libxrandr2 libxrender1 -y # for wine64
+	sudo apt-get install libavcodec58:armhf libavformat58:armhf libboost-filesystem1.74.0:armhf libboost-iostreams1.74.0:armhf \
+		libboost-program-options1.74.0:armhf libc6:armhf libcal3d12v5:armhf libcups2:armhf libcurl4:armhf libfontconfig1:armhf \
+		libfreetype6:armhf libgdk-pixbuf2.0-0:armhf libgl1-mesa-dev:armhf libgtk2.0-0:armhf libjpeg62:armhf libmpg123-0:armhf \
+		libmyguiengine3debian1v5:armhf libncurses5:armhf libncurses6:armhf libopenal1:armhf libpng16-16:armhf \
+		libsdl1.2-dev:armhf libsdl2-2.0-0:armhf libsdl2-image-2.0-0:armhf libsdl2-mixer-2.0-0:armhf libsdl2-net-2.0-0:armhf \
+		libsdl-mixer1.2:armhf libsmpeg0:armhf libsnappy1v5:armhf libstdc++6:armhf libswscale5:armhf libudev1:armhf \
+		libvorbis-dev:armhf libx11-6:armhf libx11-dev:armhf libxcb1:armhf libxcomposite1:armhf libxcursor1:armhf libxext6:armhf \
+		libxi6:armhf libxinerama1:armhf libxrandr2:armhf libxrender1:armhf libxxf86vm1:armhf mesa-va-drivers:armhf osspd:armhf \
+		pulseaudio:armhf -y # for wine on aarch64 (multiarch)
+	sudo apt-get install libasound2:armhf libpulse0:armhf libxml2:armhf libxslt1.1:armhf libxslt1-dev:armhf -y # fixes wine sound
+	sudo apt-get install libpulse0 -y # not sure if needed, but can't hurt anything
+}
+
 function run_installwinemono()  # Wine-mono replaces MS.NET 4.6 and earlier.
 {
     # MS.NET 4.6 takes a very long time to install on RPi4 in Wine and runs slower than wine-mono
     sudo apt-get install p7zip-full -y
     mkdir ~/.cache/wine 2>/dev/null
     echo -e "\n${GREENTXT}Downloading and installing wine-mono . . .${NORMTXT}\n"
-    wget -q -P ~/.cache/wine https://github.com/madewokherd/wine-mono/releases/download/wine-mono-7.1.3/wine-mono-7.1.3-x86.msi || { echo "wine-mono .msi install file download failed! Please check your internet connection and try again." && run_giveup; }
-    wine msiexec /i ~/.cache/wine/wine-mono-7.1.3-x86.msi
+    wget -q -P ~/.cache/wine https://dl.winehq.org/wine/wine-mono/7.2.0/wine-mono-7.2.0-x86.msi  || { echo "wine-mono .msi install file download failed!" && run_giveup; }
+    wine msiexec /i ~/.cache/wine/wine-mono-7.2.0-x86.msi
     rm -rf ~/.cache/wine # clean up to save disk space
 }
 
-function run_installwine()  # Download and install Wine for i386 Debian Buster (This function needs variables passed to it)
-                            #   (Example function variables: run_installwine "pi4" "devel" "7.1" "debian" "${VERSION_CODENAME}" "-1")
+function run_increasepi3swapfile()
 {
-    # Store first six strings passed to this function as variables
-    # These variables are here in the hopes that more systems might be implemented in the future. For now, they just help change wine version more easily.
-    local system="$1" #example: "pi4" - TODO: implement other systems, like pi3
-    local branch="$2" #example: "devel" or "stable" without quotes (staging requires more install steps)
-    local version="$3" #example: "7.1"
-    local build="$4" #example: debian - TODO: implement other distros, like Ubuntu
-    local dist="$5" #example: bullseye
-    local tag="$6" #example: -1
-
-    wineserver -k &> /dev/null # stop any old wine installations from running - TODO: double-check this command
-    rm -rf ~/.cache/wine # remove any old wine-mono or wine-gecko install files in case wine was installed previously
-    rm -rf ~/.local/share/applications/wine # remove any old program shortcuts
-    mkdir downloads 2>/dev/null; cd downloads
-        # Backup any old wine installs
-            rm -rf ~/wine-old 2>/dev/null; mv ~/wine ~/wine-old 2>/dev/null
-            rm -rf ~/.wine-old 2>/dev/null; mv ~/.wine ~/.wine-old 2>/dev/null
-            sudo mv /usr/local/bin/wine /usr/local/bin/wine-old 2>/dev/null
-            sudo mv /usr/local/bin/wineboot /usr/local/bin/wineboot-old 2>/dev/null
-            sudo mv /usr/local/bin/winecfg /usr/local/bin/winecfg-old 2>/dev/null
-            sudo mv /usr/local/bin/wineserver /usr/local/bin/wineserver-old 2>/dev/null
-
-        # Download, extract, and install wine-i386 onto our armhf device
-            echo -e "\n${GREENTXT}Downloading wine . . .${NORMTXT}"
-            wget -q https://dl.winehq.org/wine-builds/debian/dists/${dist}/main/binary-i386/wine-${branch}-i386_${version}~${dist}${tag}_i386.deb || { echo "wine-${branch}-i386_${version}_i386.deb download failed! Please check your internet connection and re-run the script." && run_giveup; }
-            wget -q https://dl.winehq.org/wine-builds/debian/dists/${dist}/main/binary-i386/wine-${branch}_${version}~${dist}${tag}_i386.deb || { echo "wine-${branch}_${version}_i386.deb download failed! Please check your internet connection and re-run the script." && run_giveup; }
-            echo -e "${GREENTXT}Extracting wine . . .${NORMTXT}"
-            dpkg-deb -x wine-${branch}-i386_${version}~${dist}${tag}_i386.deb wine-installer
-            dpkg-deb -x wine-${branch}_${version}~${dist}${tag}_i386.deb wine-installer
-            echo -e "${GREENTXT}Installing wine . . .${NORMTXT}\n"
-            mv wine-installer/opt/wine* ~/wine
-
-        # Install symlinks (and make 32bit launcher. Credits: grayduck, Botspot)
-            echo -e '#!/bin/bash\nsetarch linux32 -L '"$HOME/wine/bin/wine "'"$@"' | sudo tee -a /usr/local/bin/wine >/dev/null # script to launch wine programs as 32bit only
-            #sudo ln -s ~/wine/bin/wine /usr/local/bin/wine # you could also just make a symlink, but box86 only works for 32bit apps at the moment
-            sudo ln -s ~/wine/bin/wineboot /usr/local/bin/wineboot
-            sudo ln -s ~/wine/bin/winecfg /usr/local/bin/winecfg
-            sudo ln -s ~/wine/bin/wineserver /usr/local/bin/wineserver
-            sudo chmod +x /usr/local/bin/wine /usr/local/bin/wineboot /usr/local/bin/winecfg /usr/local/bin/wineserver
-    cd ..
+	# Thank you to K4OAM for the suggestion that a larger swap file can help Pi3 compatability with Wine/box86
+	# - Instructions from https://pimylifeup.com/raspberry-pi-swap-file/
+	# 73 de KI7POL (WheezyE)
+	sudo sed -i 's+#CONF_SWAPSIZE\=+CONF_SWAPSIZE\=+g' /etc/dphys-swapfile # Uncomment #CONF_SWAPSIZE= (in case it's commented-out)
+	source /etc/dphys-swapfile # Have bash read the 'CONF_SWAPSIZE=' line so that it becomes a bash variable.
+	if [[ "${CONF_SWAPSIZE}" == "" ]]; then
+		echo -e "Swap file not found. Strange...\nContinuing without swap file increase..."
+	elif (( ${CONF_SWAPSIZE} < 750 )); then
+		echo -e "Increasing swap file size to 750MByte."
+		sudo dphys-swapfile swapoff
+		sudo sed -i 's+CONF_SWAPSIZE\='"${CONF_SWAPSIZE}"'+CONF_SWAPSIZE\=750+g' /etc/dphys-swapfile
+		sudo dphys-swapfile setup
+		sudo dphys-swapfile swapon
+		echo "Continuing with kernel swap."
+	elif (( ${CONF_SWAPSIZE} >= 750 )); then
+		echo -e "Swap file size is already 750MByte or larger."
+	fi
 }
+
+
+function run_custompi3kernel() # Needed to run wine on Pi3's running RPiOS (32-bit)
+{
+	# Wine requires a linux 3G/1G VM split in the kernel.
+	#     Raspberry Pi OS (32-bit) on Pi3 has a 2G/2G split though, which will not work with Wine.
+	#     Raspberry Pi OS (64-bit) on Pi3 has a 3G/1G split, which will work with Wine.
+	# For RPiOS 32-bit on Pi3, we can either compile a custom 32-bit kernel on-device (takes several hours), download a pre-compiled 
+	#     custom 32-bit kernel (takes ~2 min, might be outdated), or switch to RPiOS 64-bit (takes ~2 min, might mess up user programs).
+	#     All methods require a reboot before wine will work.
+	# To avoid surprising the user by switching their OS from 32-bit to 64-bit without permission, we will try to download a kernel 
+	#     first, but then compile a kernel instead if the download fails.
+	#
+	# This kernel-VM-split swapping method (2G/2G -> 3G/1G) for Pi3 was copied and modified from Botspot's PiApps code with permission.
+	#     https://github.com/Botspot/pi-apps/blob/1ce54b670c13119986474224415a34b90b281d82/apps/Wine%20(x86)/install-32#L11
+	
+	# Thank you Botspot for this code!!!
+	
+	local kernelswapmethod="$1" # TODO: Have this function auto-try the other methods if the first method fails.
+	
+	if [ ! -e /proc/config.gz ]; then # TODO: Revamp this kernel switcher with custom links and more reliable vmsplit detection https://forums.raspberrypi.com/viewtopic.php?p=2042152#p2042152
+		sudo modprobe configs # Kludge: Run twice just in case (to try to help RPi3 64bit OS install)
+		sudo modprobe configs || { echo -e "Cannot find kernel 'configs' module.\nTry rebooting your Pi and re-running this install." && run_giveup; }
+		if [ ! -e /proc/config.gz ]; then
+			{ echo "/proc/config.gz does not exist after running sudo modprobe configs!" && run_giveup; }
+		fi
+	fi
+
+	vmsplit_output="$(gunzip < /proc/config.gz | grep VMSPLIT)"
+	if [ -z "$vmsplit_output" ]; then
+		kernel="$(uname -m)"
+		if [ $kernel == aarch64 ]; then
+			echo "No memory split information due to running a 64-bit kernel. Continuing..."
+		else
+			echo "No memory split information and not running a 64-bit kernel. Strange."
+			sleep 2
+			echo "Continuing..."
+		fi
+	elif echo "$vmsplit_output" | grep -q "^CONFIG_VMSPLIT_2G=y" || echo "$vmsplit_output" | grep -q "^# CONFIG_VMSPLIT_3G is not set" ; then #ensure hardware is armv7 for kernel compiling to work
+		if [[ "$PI_SERIES" != 'Pi3' && "$PI_SERIES" != "Pi3+" ]]; then
+			echo "User error: This script is not capable of handling your $PI_SERIES board with a 2G/2G memory split.\nWhatever you did to get yourself into this situation, undo it and try installing Wine again."
+			run_giveup
+		#ensure /boot/config.txt exists to make sure this is a rpi board
+		elif [ ! -f /boot/config.txt ]; then
+			echo "User error: Your system is not currently compatible with Wine. It needs a kernel with 3G/1G memory split. This is easy to do: switch to the 64-bit kernel by adding a line to /boot/config.txt. However, that file does not exist. Most likely you are trying to use Winelink on an unsupported device or operating system."
+			run_giveup
+		fi
+		
+		echo -e "You are using a kernel with a 2G/2G memory split.\nWine will not work on such systems. We will now install a custom 3G/1G kernel."
+		# 1. Install a precompiled 3G/1G kernel (about 2 minutes but might be outdated)
+		# 2. Compile a 3G/1G kernel (several hours)
+		# 3. Switch to the 64-bit kernel (about 2 minutes)
+		if [ "$kernelswapmethod" == 1 ]; then #install precompiled 3g/1g kernel
+			#backup ~/linux if it exists
+			rm -rf ~/linux.bak
+			[ -e ~/linux ] && (echo "$HOME/linux already exists, moving it to $HOME/linux.bak" ; mv -f ~/linux ~/linux.bak)
+			#download precompiled kernel
+			cd $HOME
+			echo "Downloading precompiled kernel..."
+			wget -q https://github.com/Itai-Nelken/RPi-3g-1g-kernel-wine/releases/download/5/rpi23_3g1g_kernel.zip -O ~/3g1g-rpi-kernel.zip || { echo "Failed to download prebuilt kernel!" && run_giveup; }
+			#extract precompiled kernel
+			echo "Extracting prebuilt kernel..."
+			sleep 0.5 # so user has time to read what is happening
+			unzip ~/3g1g-rpi-kernel.zip || { echo "Failed to extract kernel!" && run_giveup; }
+			cd linux || { echo "Failed to change folder to ~/linux!" && run_giveup; }
+			#install the precompiled kernel
+			export KERNEL=kernel7
+			sudo make modules_install || { echo "sudo make modules_install failed!" && run_giveup; }
+			sudo cp arch/arm/boot/dts/*.dtb /boot/ || { echo "Failed to copy dtb files to /boot!" && run_giveup; }
+			sudo cp arch/arm/boot/dts/overlays/*.dtb* /boot/overlays/ || { echo "Failed to copy overlays to /boot/overlays!" && run_giveup; }
+			sudo cp arch/arm/boot/dts/overlays/README /boot/overlays/
+			sudo cp arch/arm/boot/zImage /boot/$KERNEL.img || { echo "Failed to copy kernel to /boot/$KERNEL.img!" && run_giveup; }
+			cd
+			rm -rf linux ~/3g1g-rpi-kernel.zip
+			#message
+			echo -e "\e[1mIt appears the precompiled 3G/1G kernel has been installed successfully.\nPlease reboot and install Winelink again.\e[0m"
+			sleep infinity
+		elif [ "$kernelswapmethod" == 2 ]; then #compile 3g/1g kernel
+			#backup ~/linux if it exists
+			rm -rf ~/linux.bak
+			[ -e ~/linux ] && (echo "$HOME/linux already exists, moving it to $HOME/linux.bak" ; mv -f ~/linux ~/linux.bak)
+
+			echo "Installing necessary build packages..."
+			sudo apt-get install raspberrypi-kernel-headers build-essential bc git wget bison flex libssl-dev make libncurses-dev -y
+
+			#download kernel source code
+			git clone --depth=1 https://github.com/raspberrypi/linux || { echo "Failed to clone the raspberry pi kernel repo!" && run_giveup; }
+
+			#build for pi3
+			cd ~/linux || { echo "Failed to enter the ~/linux folder!" && run_giveup; }
+			KERNEL=kernel7
+			make -j$(($(nproc)-2)) bcm2709_defconfig || { echo "The make command exited with failure. Full command: 'make -j$(($(nproc)-2)) bcm2709_defconfig'" && run_giveup; }
+
+			#change memory split config
+			echo "Setting memory split to 3G/1G"
+			sed -i 's/CONFIG_VMSPLIT_2G=y/# CONFIG_VMSPLIT_2G is not set/g' ~/linux/.config || { echo "sed failed to edit $HOME/linux/.config file!" && run_giveup; }
+			sed -i 's/# CONFIG_VMSPLIT_3G is not set/CONFIG_VMSPLIT_3G=1/g' ~/linux/.config
+
+			echo '' | make -j$(($(nproc)-2)) zImage modules dtbs || { echo "Failed to make bcm2709_defconfig zImage modules dtbs!" && run_giveup; }
+
+			#install
+			echo "Copying new files to /boot/..."
+			sudo make modules_install || { echo "sudo make modules_install failed!" && run_giveup; }
+			sudo cp arch/arm/boot/dts/*.dtb /boot/ || { echo "Failed to copy dtb files to /boot!" && run_giveup; }
+			sudo cp arch/arm/boot/dts/overlays/*.dtb* /boot/overlays/ || { echo "Failed to copy overlays to /boot/overlays!" && run_giveup; }
+			sudo cp arch/arm/boot/dts/overlays/README /boot/overlays/
+			sudo cp arch/arm/boot/zImage /boot/$KERNEL.img || { echo "Failed to copy kernel to /boot/$KERNEL.img!" && run_giveup; }
+			cd
+			rm -rf ~/linux
+
+			#message
+			echo -e "It appears the 3G/1G kernel has been built and installed successfully.\nPlease reboot and install Winelink again."
+			sleep infinity
+		elif [ "$kernelswapmethod" == 3 ]; then #switch to 64bit kernel
+			echo "arm_64bit=1" | sudo tee --append /boot/config.txt >/dev/null
+			echo -e "The 64-bit kernel has been enabled by adding 'arm_64bit=1' to /boot/config.txt\nPlease reboot and install Winelink again."
+			sleep infinity
+		else
+			echo "Invalid method input. Must be '1', '2', or '3'."
+			run_giveup
+		fi
+	else
+		echo "Your system is using a 3G/1G kernel. Continuing..."
+	fi
+	
+	#Past this point, the pi is running a Wine-compatible kernel. Wine should now run ok.
+}
+
 
 function run_installwinetricks() # Download and install winetricks
 {
@@ -261,7 +749,7 @@ function run_installwinetricks() # Download and install winetricks
     mkdir downloads 2>/dev/null; cd downloads
         echo -e "\n${GREENTXT}Downloading and installing winetricks . . .${NORMTXT}\n"
         sudo mv /usr/local/bin/winetricks /usr/local/bin/winetricks-old 2>/dev/null # backup any old winetricks installs
-        wget -q https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks || { echo "winetricks download failed! Please check your internet connection and re-run the script." && run_giveup; } # download
+        wget -q https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks || { echo "winetricks download failed!" && run_giveup; } # download
         sudo chmod +x winetricks
         sudo mv winetricks /usr/local/bin # install
     cd ..
@@ -292,10 +780,11 @@ function run_setupwineprefix()  # Set up a new wineprefix silently.  A wineprefi
 
 function run_installahk()
 {
+    sudo apt-get install p7zip-full -y # TODO: remove redundant apt-get installs - put them at top of script.
     mkdir downloads 2>/dev/null; cd downloads
         # Download AutoHotKey
 	echo -e "\n${GREENTXT}Downloading AutoHotkey . . .${NORMTXT}\n"
-        wget -q https://github.com/AutoHotkey/AutoHotkey/releases/download/v1.0.48.05/AutoHotkey104805_Install.exe || { echo "AutoHotkey download failed! Please check your internet connection and re-run the script." && run_giveup; }
+        wget -q https://github.com/AutoHotkey/AutoHotkey/releases/download/v1.0.48.05/AutoHotkey104805_Install.exe || { echo "AutoHotkey download failed!" && run_giveup; }
         7z x AutoHotkey104805_Install.exe AutoHotkey.exe -y -bsp0 -bso0
 	mkdir ${HOME}/winelink 2>/dev/null
 	mkdir ${AHK}
@@ -309,7 +798,7 @@ function run_installrms()  # Download/extract/install RMS Express
     mkdir downloads 2>/dev/null; cd downloads
         # Download RMS Express (no matter its version number) [https://downloads.winlink.org/User%20Programs/]
             echo -e "\n${GREENTXT}Downloading and installing RMS Express . . .${NORMTXT}\n"
-            wget -q -r -l1 -np -nd -A "Winlink_Express_install_*.zip" https://downloads.winlink.org/User%20Programs || { echo "RMS Express download failed! Please check your internet connection and re-run the script." && run_giveup; }
+            wget -q -r -l1 -np -nd -A "Winlink_Express_install_*.zip" https://downloads.winlink.org/User%20Programs || { echo "RMS Express download failed!" && run_giveup; }
         
         # We could also use curl if we don't want to use wget to find the link . . .
             #RMSLINKPREFIX="https://downloads.winlink.org"
@@ -357,13 +846,13 @@ function run_installvara()  # Download / extract / install VARA HF/FM/Chat
         echo '"Decorated"="Y"'                                 >> ${HOME}/winelink/override-x11.reg
         echo '"Managed"="N"'                                   >> ${HOME}/winelink/override-x11.reg
         wine cmd /c regedit /s override-x11.reg
-	rm ${HOME}/winelink/override-x11.reg
+	rm ${HOME}/winelink/override-x11.reg 2>/dev/null # silently remove Win registry file
 
     # Install dll's needed by users of "RA-boards," like the DRA-50
     #  https://masterscommunications.com/products/radio-adapter/dra/dra-index.html
        #BOX86_NOBANNER=1 winetricks -q hid # unsure if this is needed...
        ##sudo apt-get install p7zip-full -y
-       ##wget http://uz7.ho.ua/modem_beta/ptt-dll.zip
+       ##wget -q http://uz7.ho.ua/modem_beta/ptt-dll.zip
        ##7z x ptt-dll.zip -o"$HOME/.wine/drive_c/VARA/" -y -bsp0 -bso0 # For VARA HF & VARAChat
        ##7z x ptt-dll.zip -o"$HOME/.wine/drive_c/VARA FM/" -y -bsp0 -bso0 # For VARA FM
 }
@@ -416,7 +905,7 @@ function run_makevaraupdatescript()
 				# Search the rosmodem website for a VARA HF mega.nz link of any version, then download it
 					echo -e "\n${GREENTXT}Downloading VARA HF . . .${NORMTXT}\n"
 					VARAHFLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA HF v)')
-					megadl ${VARAHFLINK} --path=${VARAUPDATE} || { echo "VARA HF download failed! Please check your internet connection and re-run the script." && run_giveup; }
+					megadl ${VARAHFLINK} --path=${VARAUPDATE} || { echo "VARA HF download failed!" && run_giveup; }
 					7z x ${VARAUPDATE}/VARA\ HF*.zip -o"${VARAUPDATE}/VARAHFInstaller" -y -bsp0 -bso0
 					mv ${VARAUPDATE}/VARAHFInstaller/VARA\ setup*.exe ~/.wine/drive_c/ # move VARA installer into wineprefix (so AHK can find it)
 
@@ -455,7 +944,7 @@ function run_makevaraupdatescript()
 				# Search the rosmodem website for a VARA FM mega.nz link of any version, then download it
 					echo -e "\n${GREENTXT}Downloading VARA FM . . .${NORMTXT}\n"
 					VARAFMLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA FM v)') # Find the mega.nz link from the rosmodem website no matter its version, then store it as a variable
-					megadl ${VARAFMLINK} --path=${VARAUPDATE} || { echo "VARA FM download failed! Please check your internet connection and re-run the script." && run_giveup; }
+					megadl ${VARAFMLINK} --path=${VARAUPDATE} || { echo "VARA FM download failed!" && run_giveup; }
 					7z x ${VARAUPDATE}/VARA\ FM*.zip -o"${VARAUPDATE}/VARAFMInstaller" -y -bsp0 -bso0
 					mv ${VARAUPDATE}/VARAFMInstaller/VARA\ FM\ setup*.exe ~/.wine/drive_c/ # move VARA installer here (so AHK can find it later)
 
@@ -490,50 +979,50 @@ function run_makevaraupdatescript()
 					echo 'StartupWMClass=varafm.exe'                                                       | sudo tee -a ${STARTMENU}/vara-fm.desktop > /dev/null
 					echo 'Categories=HamRadio'                                                             | sudo tee -a ${STARTMENU}/vara-fm.desktop > /dev/null
 
-			# Download / extract / silently install VARA SAT
-				# Search the rosmodem website for a VARA SAT mega.nz link of any version, then download it
-					echo -e "\n${GREENTXT}Downloading VARA SAT . . .${NORMTXT}\n"
-					VARAFMLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA SAT v)') # Find the mega.nz link from the rosmodem website no matter its version, then store it as a variable
-					megadl ${VARAFMLINK} --path=${VARAUPDATE} || { echo "VARA SAT download failed! Please check your internet connection and re-run the script." && run_giveup; }
-					7z x ${VARAUPDATE}/VARA\ SAT*.zip -o"${VARAUPDATE}/VARASATInstaller" -y -bsp0 -bso0
-					mv ${VARAUPDATE}/VARASATInstaller/VARA\ SAT\ setup*.exe ~/.wine/drive_c/ # move VARA installer here (so AHK can find it later)
-
-				# Create varafm_install.ahk autohotkey script
-					# The VARA installer prompts the user to hit 'OK' even during silent install (due to a secondary installer).  We will suppress this prompt with AHK.
-					echo '; AHK script to make VARA installer run completely silent'                       > ${AHK}/varasat_install.ahk
-					echo 'SetTitleMatchMode, 2'                                                            >> ${AHK}/varasat_install.ahk
-					echo 'SetTitleMatchMode, slow'                                                         >> ${AHK}/varasat_install.ahk
-					echo '        Run, VARA SAT setup (Run as Administrator).exe /SILENT, C:\'             >> ${AHK}/varasat_install.ahk
-					echo '        WinWait, VARA Setup ; Wait for the "VARA installed successfully" window' >> ${AHK}/varasat_install.ahk
-					echo '        ControlClick, Button1, VARA Setup ; Click the OK button'                 >> ${AHK}/varasat_install.ahk
-					echo '        WinWaitClose'                                                            >> ${AHK}/varasat_install.ahk
-
-				# Run varafm_install.ahk
-					echo -e "\n${GREENTXT}Installing VARA SAT . . .${NORMTXT}\n"
-					BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine ${AHK}/AutoHotkey.exe ${AHK}/varasat_install.ahk # install VARA silently using AHK
-
-				# Clean up the installation
-					rm ~/.wine/drive_c/VARA\ SAT\ setup*.exe
-					rm ${AHK}/varasat_install.ahk
-					sleep 3; sudo rm -rf ${HOME}/.local/share/applications/wine/Programs/VARA # Remove wine's auto-generated VARA SAT program icon from the start menu
-
-				# Make a VARA SAT desktop shortcut
-					echo '[Desktop Entry]'                                                                 | sudo tee ${STARTMENU}/vara-sat.desktop > /dev/null
-					echo 'Name=VARA SAT'                                                                   | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
-					echo 'GenericName=VARA SAT'                                                            | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
-					echo 'Comment=VARA SAT TNC emulated with Box86/Wine'                                   | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
-					echo 'Exec=env WINEDEBUG=-all wine '$HOME'/.wine/drive_c/VARA/VARASAT.exe'             | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
-					echo 'Type=Application'                                                                | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
-					echo 'StartupNotify=true'                                                              | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
-					echo 'Icon=29B6_VARASAT.0'                                                             | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
-					echo 'StartupWMClass=varasat.exe'                                                      | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
-					echo 'Categories=HamRadio'                                                             | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
+		#	# Download / extract / silently install VARA SAT
+		#		# Search the rosmodem website for a VARA SAT mega.nz link of any version, then download it
+		#			echo -e "\n${GREENTXT}Downloading VARA SAT . . .${NORMTXT}\n"
+		#			VARAFMLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA SAT v)') # Find the mega.nz link from the rosmodem website no matter its version, then store it as a variable
+		#			megadl ${VARAFMLINK} --path=${VARAUPDATE} || { echo "VARA SAT download failed!" && run_giveup; }
+		#			7z x ${VARAUPDATE}/VARA\ SAT*.zip -o"${VARAUPDATE}/VARASATInstaller" -y -bsp0 -bso0
+		#			mv ${VARAUPDATE}/VARASATInstaller/VARA\ SAT\ setup*.exe ~/.wine/drive_c/ # move VARA installer here (so AHK can find it later)
+		#
+		#		# Create varasat_install.ahk autohotkey script
+		#			# The VARA installer prompts the user to hit 'OK' even during silent install (due to a secondary installer).  We will suppress this prompt with AHK.
+		#			echo '; AHK script to make VARA installer run completely silent'                       > ${AHK}/varasat_install.ahk
+		#			echo 'SetTitleMatchMode, 2'                                                            >> ${AHK}/varasat_install.ahk
+		#			echo 'SetTitleMatchMode, slow'                                                         >> ${AHK}/varasat_install.ahk
+		#			echo '        Run, VARA SAT setup (Run as Administrator).exe /SILENT, C:\'             >> ${AHK}/varasat_install.ahk
+		#			echo '        WinWait, VARA Setup ; Wait for the "VARA installed successfully" window' >> ${AHK}/varasat_install.ahk
+		#			echo '        ControlClick, Button1, VARA Setup ; Click the OK button'                 >> ${AHK}/varasat_install.ahk
+		#			echo '        WinWaitClose'                                                            >> ${AHK}/varasat_install.ahk
+		#
+		#		# Run varasat_install.ahk
+		#			echo -e "\n${GREENTXT}Installing VARA SAT . . .${NORMTXT}\n"
+		#			BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine ${AHK}/AutoHotkey.exe ${AHK}/varasat_install.ahk # install VARA silently using AHK
+		#
+		#		# Clean up the installation
+		#			rm ~/.wine/drive_c/VARA\ SAT\ setup*.exe
+		#			rm ${AHK}/varasat_install.ahk
+		#			sleep 3; sudo rm -rf ${HOME}/.local/share/applications/wine/Programs/VARA # Remove wine's auto-generated VARA SAT program icon from the start menu
+		#
+		#		# Make a VARA SAT desktop shortcut
+		#			echo '[Desktop Entry]'                                                                 | sudo tee ${STARTMENU}/vara-sat.desktop > /dev/null
+		#			echo 'Name=VARA SAT'                                                                   | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
+		#			echo 'GenericName=VARA SAT'                                                            | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
+		#			echo 'Comment=VARA SAT TNC emulated with Box86/Wine'                                   | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
+		#			echo 'Exec=env WINEDEBUG=-all wine '$HOME'/.wine/drive_c/VARA/VARASAT.exe'             | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
+		#			echo 'Type=Application'                                                                | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
+		#			echo 'StartupNotify=true'                                                              | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
+		#			echo 'Icon=29B6_VARASAT.0'                                                             | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
+		#			echo 'StartupWMClass=varasat.exe'                                                      | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
+		#			echo 'Categories=HamRadio'                                                             | sudo tee -a ${STARTMENU}/vara-sat.desktop > /dev/null
 
 			# Download / extract / silently install VARA Chat
 				# Search the rosmodem website for a VARA Chat mega.nz link of any version, then download it
 					echo -e "\n${GREENTXT}Downloading VARA Chat . . .${NORMTXT}\n"
 					VARACHATLINK=$(curl -s https://rosmodem.wordpress.com/ | grep -oP '(?=https://mega.nz).*?(?=" target="_blank" rel="noopener noreferrer">VARA Chat v)') # Find the mega.nz link from the rosmodem website no matter its version, then store it as a variable
-					megadl ${VARACHATLINK} --path=${VARAUPDATE} || { echo "VARA Chat download failed! Please check your internet connection and re-run the script." && run_giveup; }
+					megadl ${VARACHATLINK} --path=${VARAUPDATE} || { echo "VARA Chat download failed!" && run_giveup; }
 					7z x ${VARAUPDATE}/VARA\ Chat*.zip -o"${VARAUPDATE}/VARAChatInstaller" -y -bsp0 -bso0
 
 				# Run the VARA Chat installer silently
@@ -629,6 +1118,15 @@ function run_makevarasoundcardsetupscript()
 			echo '        WinActivate, VARA HF'                                                    >> ${AHK}/varahf_configure.ahk
 			echo '        WinWait, VARA HF ; Wait for VARA HF to open'                             >> ${AHK}/varahf_configure.ahk
 			echo '        Sleep 2500 ; If we dont wait at least 2000 for VARA then AHK wont work'  >> ${AHK}/varahf_configure.ahk
+			echo '        Send, !{s} ; Open view menu for user to turn off waterfall'              >> ${AHK}/varahf_configure.ahk
+			echo '        Sleep 100'                                                               >> ${AHK}/varahf_configure.ahk
+			echo '        Send, {Right}'                                                           >> ${AHK}/varahf_configure.ahk
+			echo '        Sleep, 100'                                                              >> ${AHK}/varahf_configure.ahk
+			echo '        Send, {Down}'                                                            >> ${AHK}/varahf_configure.ahk
+			echo '        Sleep, 100'                                                              >> ${AHK}/varahf_configure.ahk
+			echo '        Send, {Down}'                                                            >> ${AHK}/varahf_configure.ahk
+			echo '        Sleep, 100'                                                              >> ${AHK}/varahf_configure.ahk
+			echo '        Send, {Enter}'                                                           >> ${AHK}/varahf_configure.ahk
 			echo '        Send, !{s} ; Open SoundCard menu for user to set up sound cards'         >> ${AHK}/varahf_configure.ahk
 			echo '        Sleep 500'                                                               >> ${AHK}/varahf_configure.ahk
 			echo '        Send, {Down}'                                                            >> ${AHK}/varahf_configure.ahk
@@ -641,9 +1139,6 @@ function run_makevarasoundcardsetupscript()
 			BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine ${HOME}/winelink/ahk/AutoHotkey.exe ${AHK}/varahf_configure.ahk # nobanner option to make console prettier
 			rm ${AHK}/varahf_configure.ahk
 			sleep 5
-		
-		# Turn off VARA HF's waterfall (change 'View=1' to 'View=3' in VARA.ini). INI file shows up after first run of VARA HF.
-			sed -i 's+View\=1+View\=3+g' ~/.wine/drive_c/VARA/VARA.ini
 		
 		# Guide the user to the VARA FM audio setup menu (configure hardware soundcard input/output)
 			clear
@@ -662,6 +1157,13 @@ function run_makevarasoundcardsetupscript()
 			echo '        WinActivate, VARA FM'                                                    >> ${AHK}/varafm_configure.ahk
 			echo '        WinWait, VARA FM ; Wait for VARA FM to open'                             >> ${AHK}/varafm_configure.ahk
 			echo '        Sleep 2000 ; If we dont wait at least 2000 for VARA then AHK wont work'  >> ${AHK}/varafm_configure.ahk
+			echo '        Send, !{s} ; Open view menu for user to turn off waterfall'              >> ${AHK}/varafm_configure.ahk
+			echo '        Sleep 100'                                                               >> ${AHK}/varafm_configure.ahk
+			echo '        Send, {Right}'                                                           >> ${AHK}/varafm_configure.ahk
+			echo '        Sleep, 100'                                                              >> ${AHK}/varafm_configure.ahk
+			echo '        Send, {Down}'                                                            >> ${AHK}/varafm_configure.ahk
+			echo '        Sleep, 100'                                                              >> ${AHK}/varafm_configure.ahk
+			echo '        Send, {Enter}'                                                           >> ${AHK}/varafm_configure.ahk
 			echo '        Send, !{s} ; Open SoundCard menu for user to set up sound cards'         >> ${AHK}/varafm_configure.ahk
 			echo '        Sleep 500'                                                               >> ${AHK}/varafm_configure.ahk
 			echo '        Send, {Down}'                                                            >> ${AHK}/varafm_configure.ahk
@@ -674,53 +1176,50 @@ function run_makevarasoundcardsetupscript()
 			BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine ${HOME}/winelink/ahk/AutoHotkey.exe ${AHK}/varafm_configure.ahk # Nobanner option to make console prettier
 			rm ${AHK}/varafm_configure.ahk
 			sleep 5
-		
-		# Turn off VARA FM's graphics (change 'View=1' to 'View=3' in VARAFM.ini). INI file shows up after first run of VARA FM
-			sed -i 's+View\=1+View\=3+g' ~/.wine/drive_c/VARA\ FM/VARAFM.ini
 			
-		# Guide the user to the VARA SAT audio setup menu (configure hardware soundcard input/output)
-			clear
-			echo -e "\n${GREENTXT}Configuring VARA SAT . . .${NORMTXT}\n"
-			echo -e "\n${GREENTXT}Please set up your soundcard input/output for VARA SAT\n(please click 'Ok' on the user prompt textbox to continue)${NORMTXT}\n"
-			zenity --info --height 100 --width 350 --text="We will now setup your soundcards for VARA SAT. \n\nInstall will continue once you have closed the VARA Settings menu." --title="VARA SAT Soundcard Setup"
-			echo -e "\n${GREENTXT}Loading VARA SAT now . . .${NORMTXT}\n"
-
-		# Create/run varasat_configure.ahk
-			# We will disable all graphics except gauges to help RPi4 CPU. Users can enable these if they have better CPU
-			# We will then open the soundcard menu for users so that they can set up their sound cards
-			# After the settings menu is closed, we will close VARA SAT
-			echo '; AHK script to assist users in setting up VARA on its first run'                > ${AHK}/varasat_configure.ahk
-			echo 'SetTitleMatchMode, 2'                                                            >> ${AHK}/varasat_configure.ahk
-			echo 'SetTitleMatchMode, slow'                                                         >> ${AHK}/varasat_configure.ahk
-			echo '        Run, VARASAT.exe, C:\VARA'                                               >> ${AHK}/varasat_configure.ahk
-			echo '        WinActivate, VARA SAT'                                                   >> ${AHK}/varasat_configure.ahk
-			echo '        WinWait, VARA SAT ; Wait for VARA HF to open'                            >> ${AHK}/varasat_configure.ahk
-			echo '        Sleep 2500 ; If we dont wait at least 2000 for VARA then AHK wont work'  >> ${AHK}/varasat_configure.ahk
-			echo '        Send, !{s} ; Open view menu for user to turn off waterfall'              >> ${AHK}/varasat_configure.ahk
-			echo '        Sleep 100'                                                               >> ${AHK}/varasat_configure.ahk
-			echo '        Send, {Right}'                                                           >> ${AHK}/varasat_configure.ahk
-			echo '        Sleep, 100'                                                              >> ${AHK}/varasat_configure.ahk
-			echo '        Send, {Right}'                                                           >> ${AHK}/varasat_configure.ahk
-			echo '        Sleep, 100'                                                              >> ${AHK}/varasat_configure.ahk
-			echo '        Send, {Down}'                                                            >> ${AHK}/varasat_configure.ahk
-			echo '        Sleep, 100'                                                              >> ${AHK}/varasat_configure.ahk
-			echo '        Send, {Down}'                                                            >> ${AHK}/varasat_configure.ahk
-			echo '        Sleep, 100'                                                              >> ${AHK}/varasat_configure.ahk
-			echo '        Send, {Down}'                                                            >> ${AHK}/varasat_configure.ahk
-			echo '        Sleep, 100'                                                              >> ${AHK}/varasat_configure.ahk
-			echo '        Send, {Enter}'                                                           >> ${AHK}/varasat_configure.ahk
-			echo '        Send, !{s} ; Open SoundCard menu for user to set up sound cards'         >> ${AHK}/varasat_configure.ahk
-			echo '        Sleep 500'                                                               >> ${AHK}/varasat_configure.ahk
-			echo '        Send, {Down}'                                                            >> ${AHK}/varasat_configure.ahk
-			echo '        Sleep, 100'                                                              >> ${AHK}/varasat_configure.ahk
-			echo '        Send, {Enter}'                                                           >> ${AHK}/varasat_configure.ahk
-			echo '        Sleep 5000'                                                              >> ${AHK}/varasat_configure.ahk
-			echo '        WinWaitClose, SoundCard ; Wait for user to finish setting up soundcard'  >> ${AHK}/varasat_configure.ahk
-			echo '        Sleep 100'                                                               >> ${AHK}/varasat_configure.ahk
-			echo '        WinClose, VARA SAT ; Close VARA'                                         >> ${AHK}/varasat_configure.ahk
-			BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine ${HOME}/winelink/ahk/AutoHotkey.exe ${AHK}/varasat_configure.ahk # nobanner option to make console prettier
-			rm ${AHK}/varasat_configure.ahk
-			sleep 5
+	#	# Guide the user to the VARA SAT audio setup menu (configure hardware soundcard input/output)
+	#		clear
+	#		echo -e "\n${GREENTXT}Configuring VARA SAT . . .${NORMTXT}\n"
+	#		echo -e "\n${GREENTXT}Please set up your soundcard input/output for VARA SAT\n(please click 'Ok' on the user prompt textbox to continue)${NORMTXT}\n"
+	#		zenity --info --height 100 --width 350 --text="We will now setup your soundcards for VARA SAT. \n\nInstall will continue once you have closed the VARA Settings menu." --title="VARA SAT Soundcard Setup"
+	#		echo -e "\n${GREENTXT}Loading VARA SAT now . . .${NORMTXT}\n"
+	#
+	#	# Create/run varasat_configure.ahk
+	#		# We will disable all graphics except gauges to help RPi4 CPU. Users can enable these if they have better CPU
+	#		# We will then open the soundcard menu for users so that they can set up their sound cards
+	#		# After the settings menu is closed, we will close VARA SAT
+	#		echo '; AHK script to assist users in setting up VARA on its first run'                > ${AHK}/varasat_configure.ahk
+	#		echo 'SetTitleMatchMode, 2'                                                            >> ${AHK}/varasat_configure.ahk
+	#		echo 'SetTitleMatchMode, slow'                                                         >> ${AHK}/varasat_configure.ahk
+	#		echo '        Run, VARASAT.exe, C:\VARA'                                               >> ${AHK}/varasat_configure.ahk
+	#		echo '        WinActivate, VARA SAT'                                                   >> ${AHK}/varasat_configure.ahk
+	#		echo '        WinWait, VARA SAT ; Wait for VARA HF to open'                            >> ${AHK}/varasat_configure.ahk
+	#		echo '        Sleep 2500 ; If we dont wait at least 2000 for VARA then AHK wont work'  >> ${AHK}/varasat_configure.ahk
+	#		echo '        Send, !{s} ; Open view menu for user to turn off waterfall'              >> ${AHK}/varasat_configure.ahk
+	#		echo '        Sleep 100'                                                               >> ${AHK}/varasat_configure.ahk
+	#		echo '        Send, {Right}'                                                           >> ${AHK}/varasat_configure.ahk
+	#		echo '        Sleep, 100'                                                              >> ${AHK}/varasat_configure.ahk
+	#		echo '        Send, {Right}'                                                           >> ${AHK}/varasat_configure.ahk
+	#		echo '        Sleep, 100'                                                              >> ${AHK}/varasat_configure.ahk
+	#		echo '        Send, {Down}'                                                            >> ${AHK}/varasat_configure.ahk
+	#		echo '        Sleep, 100'                                                              >> ${AHK}/varasat_configure.ahk
+	#		echo '        Send, {Down}'                                                            >> ${AHK}/varasat_configure.ahk
+	#		echo '        Sleep, 100'                                                              >> ${AHK}/varasat_configure.ahk
+	#		echo '        Send, {Down}'                                                            >> ${AHK}/varasat_configure.ahk
+	#		echo '        Sleep, 100'                                                              >> ${AHK}/varasat_configure.ahk
+	#		echo '        Send, {Enter}'                                                           >> ${AHK}/varasat_configure.ahk
+	#		echo '        Send, !{s} ; Open SoundCard menu for user to set up sound cards'         >> ${AHK}/varasat_configure.ahk
+	#		echo '        Sleep 500'                                                               >> ${AHK}/varasat_configure.ahk
+	#		echo '        Send, {Down}'                                                            >> ${AHK}/varasat_configure.ahk
+	#		echo '        Sleep, 100'                                                              >> ${AHK}/varasat_configure.ahk
+	#		echo '        Send, {Enter}'                                                           >> ${AHK}/varasat_configure.ahk
+	#		echo '        Sleep 5000'                                                              >> ${AHK}/varasat_configure.ahk
+	#		echo '        WinWaitClose, SoundCard ; Wait for user to finish setting up soundcard'  >> ${AHK}/varasat_configure.ahk
+	#		echo '        Sleep 100'                                                               >> ${AHK}/varasat_configure.ahk
+	#		echo '        WinClose, VARA SAT ; Close VARA'                                         >> ${AHK}/varasat_configure.ahk
+	#		BOX86_NOBANNER=1 BOX86_DYNAREC_BIGBLOCK=0 wine ${HOME}/winelink/ahk/AutoHotkey.exe ${AHK}/varasat_configure.ahk # nobanner option to make console prettier
+	#		rm ${AHK}/varasat_configure.ahk
+	#		sleep 5
 		
 		clear
 	EOM
@@ -741,9 +1240,17 @@ function run_makewineserverkscript()  # Make a script for the desktop that will 
 {
     sudo apt-get install zenity -y
     # Create 'Reset\ Wine.sh'
-        echo '#!/bin/bash'               > ${HOME}/winelink/Reset\ Wine
-        echo ''                          >> ${HOME}/winelink/Reset\ Wine
-        echo 'wineserver -k'             >> ${HOME}/winelink/Reset\ Wine
+        echo '#!/bin/bash'                                                                                         > ${HOME}/winelink/Reset\ Wine
+        echo ''                                                                                                    >> ${HOME}/winelink/Reset\ Wine
+	echo '# Turn off the waterfalls for VARA HF/FM/Sat (change 'View=1' to 'View=3' in their VARA.ini files).' >> ${HOME}/winelink/Reset\ Wine
+	echo '# (INI files show up after first run of each VARA program)'                                          >> ${HOME}/winelink/Reset\ Wine
+	echo 'sed -i 's+View\=1+View\=3+g' ~/.wine/drive_c/VARA/VARA.ini'                                          >> ${HOME}/winelink/Reset\ Wine
+	echo 'sed -i 's+WaterFall\=1+WaterFall\=0+g' ~/.wine/drive_c/VARA/VARA.ini'                                >> ${HOME}/winelink/Reset\ Wine
+	echo 'sed -i 's+View\=1+View\=3+g' ~/.wine/drive_c/VARA/VARASAT.ini'                                       >> ${HOME}/winelink/Reset\ Wine
+	echo 'sed -i 's+WaterFall\=1+WaterFall\=0+g' ~/.wine/drive_c/VARA/VARASAT.ini'                             >> ${HOME}/winelink/Reset\ Wine
+	echo 'sed -i 's+View\=1+View\=3+g' ~/.wine/drive_c/VARA\ FM/VARAFM.ini'                                    >> ${HOME}/winelink/Reset\ Wine
+	echo ''                                                                                                    >> ${HOME}/winelink/Reset\ Wine
+        echo 'wineserver -k'                                                                                       >> ${HOME}/winelink/Reset\ Wine
         echo 'zenity --info --timeout=8 --height 150 --width 500 --text="Wine has been reset so that Winlink Express and VARA will run again.\\n\\nIf you try to run RMS Express again and it crashes or doesn'\''t open, just keep trying to run it.  It should open eventually after enough tries." --title="Wine has been reset"'          >> ${HOME}/winelink/Reset\ Wine
         sudo chmod +x ${HOME}/winelink/Reset\ Wine
 	
@@ -774,6 +1281,7 @@ function run_makeuninstallscript()
 				${STARTMENU}/vara-sat.desktop ${STARTMENU}/vara-chat.desktop ${STARTMENU}/vara-soundcardsetup.desktop \
 				${STARTMENU}/vara-update.desktop ${STARTMENU}/resetwine.desktop 2>/dev/null # remove old shortcuts
 			sudo rm -rf ${HOME}/winelink 2>/dev/null
+			rm ${HOME}/RMS\ Express\ *.log 2>/dev/null # silently remove old RMS Express logs
 
 			# Ask user if they would like to remove wine & box86
 				zenity --question --height 150 --width 500 --text="Winelink uninstalled\\n\\nWould you also like to remove Wine and Box86?" --title="Remove Wine & Box86?"
@@ -829,7 +1337,7 @@ function run_detect_arch()  # Finds what kind of processor we're running (aarch6
     #   Exagear RPi3/4 (32bit modified qemu chroot): i686 (if I remember correctly)
 }
 
-function run_gather_os_info()
+function run_detect_os()
 {
     # To my knowledge . . .
     #    Most post-2012 distros should have a standard '/etc/os-release' file for finding OS
@@ -850,9 +1358,9 @@ function run_gather_os_info()
     # We will also have to determine package manager later, which we might try to do multiple ways (whitelist based on distro/version vs runtime detection)
 
     # Try to find the os-release file on Linux systems
-    if [ -e /etc/os-release ];       then OS_INFOFILE='/etc/os-release'     && echo "Found an OS info file located at ${OS_INFOFILE}"
-    elif [ -e /usr/lib/os-release ]; then OS_INFOFILE='/usr/lib/os-release' && echo "Found an OS info file located at ${OS_INFOFILE}"
-    elif [ -e /etc/*elease ];        then OS_INFOFILE='/etc/*elease'        && echo "Found an OS info file located at ${OS_INFOFILE}"
+    if [ -e /etc/os-release ];       then OS_INFOFILE='/etc/os-release'     #&& echo "Found an OS info file located at ${OS_INFOFILE}"
+    elif [ -e /usr/lib/os-release ]; then OS_INFOFILE='/usr/lib/os-release' #&& echo "Found an OS info file located at ${OS_INFOFILE}"
+    elif [ -e /etc/*elease ];        then OS_INFOFILE='/etc/*elease'        #&& echo "Found an OS info file located at ${OS_INFOFILE}"
     # Add mac OS  https://apple.stackexchange.com/questions/255546/how-to-find-file-release-in-os-x-el-capitan-10-11-6
     # Add chrome OS
     # Add chroot Android? (uname -o  can be used to find "Android")
@@ -861,6 +1369,425 @@ function run_gather_os_info()
     
     # Load OS-Release File vars into memory (reads vars like "NAME", "ID", "VERSION_ID", "PRETTY_NAME", and "HOME_URL")
     source "${OS_INFOFILE}"
+    
+    # TODO: Add Termux detection
+}
+
+function run_detect_rpi()
+{
+	# Learn about our user's RPi hardware configuration by reading the revision number stored in '/proc/cpuinfo'
+	
+	# Get revision number
+		#local HEXREVISION="$1" # uncomment this (and comment-out the line below this) if you want to pass revision numbers to this script instead of auto-detecting
+		local HEXREVISION=$(cat /proc/cpuinfo | grep Revision | cut -d ' ' -f 2) # Get revision number from cpuinfo (revision number is in hex)
+	
+	# Convert revision number into a 32 bit binary string with leading zero's (name it "REVCODE")
+		local BINREVISION=$(echo "obase=2; ibase=16; ${HEXREVISION^^}" | bc) # Convert revision number from hex to binary (bc needs upper-case)
+		local COUNTBITS=${#BINREVISION}
+		if (( "$COUNTBITS" < "32" )); then # If the revision number is not 32 bits long, add leading zero's to it - Note: $(printf "%032d\n" $BINREVISION) doesn't work with large numbers
+			local ZEROSNEEDED=$((32-COUNTBITS))
+			local LEADINGZEROS=$(printf "%0${ZEROSNEEDED}d\n" 0)
+			local REVCODE=${LEADINGZEROS}${BINREVISION}
+		elif (( "$COUNTBITS" == "32" )); then
+			REVCODE=${BINREVISION}
+		else
+			echo "Something went wrong with calculating the Pi's revision number."
+			run_giveup
+		fi
+	
+	# Parse $REVCODE (find substrings, determine new-format vs old-format, decipher/store info in variables, print info for the user).
+		# Now that REVCODE is readable in binary, create hexadecimal substrings from it.
+		#       New-style revision codes: NOQuuuWwFMMMCCCCPPPPTTTTTTTTRRRR
+		#         - https://www.raspberrypi.com/documentation/computers/raspberry-pi.html
+		#         - https://github.com/raspberrypi/documentation/blob/develop/documentation/asciidoc/computers/raspberry-pi/revision-codes.adoc
+		#       If a is constant, b=${a:12:5} does substring extraction where 12 is the offset (zero-based) and 5 is the length.
+		#         - https://stackoverflow.com/questions/428109/extract-substring-in-bash
+		local N=${REVCODE:0:1}                                           # Overvoltage (0: Overvoltage allowed, 1: Overvoltage disallowed)
+		local O=${REVCODE:1:1}                                           # OTP Program (0: OTP programming allowed, 1: OTP programming disallowed)
+		local Q=${REVCODE:2:1}                                           # OTP Read (0: OTP reading allowed, 1: OTP reading disallowed)
+		#local uuu=$(echo "obase=16; ibase=2; ${REVCODE:3:3}" | bc)      # Unused bits
+		local W=${REVCODE:6:1}                                           # Warranty bit [starting with RPi2/Zero] (0: Warranty is intact, 1: Warranty has been voided by overclocking)
+		local w=${REVCODE:7:1}                                           # Unused bit [starting with RPi2/Zero] / warranty bit [prior to RPi2/Zero]
+		local F=${REVCODE:8:1}                                           # New flag (1: new-style revision, 0: old-style revision)
+		local MMM=$(echo "obase=16; ibase=2; ${REVCODE:9:3}" | bc)       # Memory size (0: 256MB, 1: 512MB, 2: 1GB, 3: 2GB, 4: 4GB, 5: 8GB)
+		local CCCC=$(echo "obase=16; ibase=2; ${REVCODE:12:4}" | bc)     # Manufacturer (0: Sony UK, 1: Egoman, 2: Embest, 3: Sony Japan, 4: Embest, 5: Stadium)
+		local PPPP=$(echo "obase=16; ibase=2; ${REVCODE:16:4}" | bc)     # Processor (0: BCM2835, 1: BCM2836, 2: BCM2837, 3: BCM2711)
+		local TTTTTTTT=$(echo "obase=16; ibase=2; ${REVCODE:20:8}" | bc) # Type (0: A, 1: B, 2: A+, 3: B+, 4: 2B, 5: Alpha (early prototype), 6: CM1, 8: 3B, 
+		                                                                 #       9: Zero, A: CM3, C: Zero W, D: 3B+, E: 3A+, F: Internal use only, 10: CM3+, 
+		                                                                 #       11: 4B, 12: Zero 2 W, 13: 400, 14: CM4)
+		local RRRR=$(echo "obase=16; ibase=2; ${REVCODE:28:4}" | bc)     # Revision (0, 1, 2, etc.)
+		
+		# Zero-out our variables in case this function runs twice (this step might be redundant)
+		PI_OVERVOLTAGE=""
+		PI_OTPPROGRAM=""
+		PI_OTPREAD=""
+		PI_WARRANTY=""
+		PI_RAM=""
+		PI_MANUFACTURER=""
+		PI_PROCESSOR=""
+		PI_TYPE=""
+		PI_REVISION=""
+		
+		if [ "$F" = "0" ]; then
+			# Old-style revision codes [Leading 0x100 = warranty is void from overclocking (the "w" binary bit is set)]:
+			case $HEXREVISION in
+				"0002" | "1000002")
+					PI_TYPE="1B"
+					PI_REVISION="1.0"
+					PI_RAM="256MB"
+					PI_MANUFACTURER="Egoman"
+					;;
+				"0003" | "1000003")
+					PI_TYPE="1B"
+					PI_REVISION="1.0"
+					PI_RAM="256MB"
+					PI_MANUFACTURER="Egoman"
+					;;
+				"0004" | "1000004")
+					PI_TYPE="1B"
+					PI_REVISION="2.0"
+					PI_RAM="256MB"
+					PI_MANUFACTURER="Sony UK"
+					;;
+				"0005" | "1000005")
+					PI_TYPE="1B"
+					PI_REVISION="2.0"
+					PI_RAM="256MB"
+					PI_MANUFACTURER="Qisda"
+					;;
+				"0006" | "1000006")
+					PI_TYPE="1B"
+					PI_REVISION="2.0"
+					PI_RAM="256MB"
+					PI_MANUFACTURER="Egoman"
+					;;
+				"0007" | "1000007")
+					PI_TYPE="1A"
+					PI_REVISION="2.0"
+					PI_RAM="256MB"
+					PI_MANUFACTURER="Egoman"
+					;;
+				"0008" | "1000008")
+					PI_TYPE="1A"
+					PI_REVISION="2.0"
+					PI_RAM="256MB"
+					PI_MANUFACTURER="Sony UK"
+					;;
+				"0009" | "1000009")
+					PI_TYPE="1A"
+					PI_REVISION="2.0"
+					PI_RAM="256MB"
+					PI_MANUFACTURER="Qisda"
+					;;
+				"000d" | "100000d")
+					PI_TYPE="1B"
+					PI_REVISION="2.0"
+					PI_RAM="512MB"
+					PI_MANUFACTURER="Egoman"
+					;;
+				"000e" | "100000e")
+					PI_TYPE="1B"
+					PI_REVISION="2.0"
+					PI_RAM="512MB"
+					PI_MANUFACTURER="Sony UK"
+					;;
+				"000f" | "100000f")
+					PI_TYPE="1B"
+					PI_REVISION="2.0"
+					PI_RAM="512MB"
+					PI_MANUFACTURER="Egoman"
+					;;
+				"0010" | "1000010")
+					PI_TYPE="1B+"
+					PI_REVISION="1.2"
+					PI_RAM="512MB"
+					PI_MANUFACTURER="Sony UK"
+					;;
+				"0011" | "1000011")
+					PI_TYPE="CM1"
+					PI_REVISION="1.0"
+					PI_RAM="512MB"
+					PI_MANUFACTURER="Sony UK"
+					;;
+				"0012" | "1000012")
+					PI_TYPE="1A+"
+					PI_REVISION="1.1"
+					PI_RAM="256MB"
+					PI_MANUFACTURER="Sony UK"
+					;;
+				"0013" | "1000013")
+					PI_TYPE="1B+"
+					PI_REVISION="1.2"
+					PI_RAM="512MB"
+					PI_MANUFACTURER="Embest"
+					;;
+				"0014" | "1000014")
+					PI_TYPE="CM1"
+					PI_REVISION="1.0"
+					PI_RAM="512MB"
+					PI_MANUFACTURER="Embest"
+					;;
+				"0015" | "1000015")
+					PI_TYPE="1A+"
+					PI_REVISION="1.1"
+					PI_RAM="256MB/512MB"
+					PI_MANUFACTURER="Embest"
+					;;
+				*)
+					PI_TYPE="UNKNOWN"
+					PI_REVISION="UNKNOWN"
+					PI_RAM="UNKNOWN"
+					PI_MANUFACTURER="UNKNOWN"
+					echo "ERROR: Unable to parse Raspberry Pi old-style revision code"
+					run_giveup
+					;;
+			esac
+			
+			case $w in
+				"0")
+					PI_WARRANTY="intact"
+					;;
+				"1")
+					PI_WARRANTY="voided by overclocking"
+					;;
+				*)
+					PI_WARRANTY="UNKNOWN"
+					echo "ERROR: Unable to parse Raspberry Pi old-style overclock/warranty code."
+					run_giveup
+					;;
+			esac
+			
+			echo -e "\nRaspberry Pi Model ${PI_TYPE} Rev ${PI_REVISION} with ${PI_RAM} of RAM. Manufactured by ${PI_MANUFACTURER}."
+			echo "(Warranty ${PI_WARRANTY})"
+			
+		elif [ "$F" = "1" ]; then
+			# New-style revision codes:
+			case $N in
+				"0")
+					PI_OVERVOLTAGE="allowed"
+					;;
+				"1")
+					PI_OVERVOLTAGE="disallowed"
+					;;
+				*)
+					PI_OVERVOLTAGE="UNKNOWN"
+					echo "ERROR: Unable to parse Raspberry Pi overvoltage allowance bit."
+					run_giveup
+					;;
+			esac
+			
+			case $O in
+				"0")
+					PI_OTPPROGRAM="allowed"
+					;;
+				"1")
+					PI_OTPPROGRAM="disallowed"
+					;;
+				*)
+					PI_OTPPROGRAM="UNKNOWN"
+					echo "ERROR: Unable to parse Raspberry Pi OTP programming allowance bit."
+					run_giveup
+					;;
+			esac
+			
+			case $Q in
+				"0")
+					PI_OTPREAD="allowed"
+					;;
+				"1")
+					PI_OTPREAD="disallowed"
+					;;
+				*)
+					PI_OTPREAD="UNKNOWN"
+					echo "ERROR: Unable to parse Raspberry Pi OTP reading allowance bit."
+					run_giveup
+					;;
+			esac
+			
+			case $W in
+				"0")
+					PI_WARRANTY="intact"
+					;;
+				"1")
+					PI_WARRANTY="voided by overclocking"
+					;;
+				*)
+					PI_WARRANTY="UNKNOWN"
+					echo "ERROR: Unable to parse Raspberry Pi new-style overclock/warranty code."
+					run_giveup
+					;;
+			esac
+			
+			case $MMM in
+				"0")
+					PI_RAM="256MB"
+					;;
+				"1")
+					PI_RAM="512MB"
+					;;
+				"2")
+					PI_RAM="1GB"
+					;;
+				"3")
+					PI_RAM="2GB"
+					;;
+				"4")
+					PI_RAM="4GB"
+					;;
+				"5")
+					PI_RAM="8GB"
+					;;
+				*)
+					PI_RAM="UNKNOWN"
+					echo "ERROR: Unable to parse Raspberry Pi RAM type code."
+					run_giveup
+					;;
+			esac
+			
+			case $CCCC in
+				"0")
+					PI_MANUFACTURER="Sony UK"
+					;;
+				"1")
+					PI_MANUFACTURER="Egoman"
+					;;
+				"2")
+					PI_MANUFACTURER="Embest"
+					;;
+				"3")
+					PI_MANUFACTURER="Sony Japan"
+					;;
+				"4")
+					PI_MANUFACTURER="Embest"
+					;;
+				"5")
+					PI_MANUFACTURER="Stadium"
+					;;
+				*)
+					PI_MANUFACTURER="UNKNOWN"
+					echo "ERROR: Unable to parse Raspberry Pi manufacturer code."
+					run_giveup
+					;;
+			esac
+			
+			case $PPPP in
+				"0")
+					PI_PROCESSOR="BCM2835"
+					;;
+				"1")
+					PI_PROCESSOR="BCM2836"
+					;;
+				"2")
+					PI_PROCESSOR="BCM2837"
+					;;
+				"3")
+					PI_PROCESSOR="BCM2711"
+					;;
+				*)
+					PI_PROCESSOR="UNKNOWN"
+					echo "ERROR: Unable to parse Raspberry Pi processor type code."
+					run_giveup
+					;;
+			esac
+			
+			case $TTTTTTTT in
+				"0")
+					PI_TYPE="1A"
+					;;
+				"1")
+					PI_TYPE="1B"
+					;;
+				"2")
+					PI_TYPE="1A+"
+					;;
+				"3")
+					PI_TYPE="1B+"
+					;;
+				"4")
+					PI_TYPE="2B"
+					;;
+				"5")
+					PI_TYPE="Alpha (early prototype)"
+					;;
+				"6")
+					PI_TYPE="CM1"
+					;;
+				"8")
+					PI_TYPE="3B"
+					;;
+				"9")
+					PI_TYPE="Zero"
+					;;
+				"A")
+					PI_TYPE="CM3"
+					;;
+				"C")
+					PI_TYPE="Zero W"
+					;;
+				"D")
+					PI_TYPE="3B+"
+					;;
+				"E")
+					PI_TYPE="3A+"
+					;;
+				"F")
+					PI_TYPE="Internal use only"
+					;;
+				"10")
+					PI_TYPE="CM3+"
+					;;
+				"11")
+					PI_TYPE="4B"
+					;;
+				"12")
+					PI_TYPE="Zero 2 W"
+					;;
+				"13")
+					PI_TYPE="400"
+					;;
+				"14")
+					PI_TYPE="CM4"
+					;;
+				*)
+					PI_TYPE="UNKNOWN"
+					echo "ERROR: Unable to parse Raspberry Pi model code."
+					run_giveup
+					;;
+			esac
+			
+			PI_REVISION="1.${RRRR}"
+			
+			echo -e "\nRaspberry Pi Model ${PI_TYPE} Rev ${PI_REVISION} ${PI_PROCESSOR} with ${PI_RAM} of RAM. Manufactured by ${PI_MANUFACTURER}."
+			echo "(Overvoltage ${PI_OVERVOLTAGE}. OTP programming ${PI_OTPPROGRAM}. OTP reading ${PI_OTPREAD}. Warranty ${PI_WARRANTY})"
+		else
+			echo "ERROR: Could not read the Raspberry Pi's revision code version bit."
+			run_giveup
+		fi
+		
+	# Categorize the Pi into a series (based on the $PI_TYPE variable)
+		if [ "$PI_TYPE" = "4B" ] || [ "$PI_TYPE" = "400" ] || [ "$PI_TYPE" = "CM4" ]; then
+			PI_SERIES=Pi4
+		elif [ "$PI_TYPE" = "3A+" ] || [  "$PI_TYPE" = "3B+" ] || [  "$PI_TYPE" = "CM3+" ]; then
+			PI_SERIES=Pi3+
+		elif [ "$PI_TYPE" = "Zero 2 W" ]; then
+			PI_SERIES=PiZ2
+		elif [ "$PI_TYPE" = "3B" ] || [  "$PI_TYPE" = "CM3" ]; then
+			PI_SERIES=Pi3
+		elif [ "$PI_TYPE" = "Zero" ] || [ "$PI_TYPE" = "Zero W" ]; then
+			PI_SERIES=PiZ1
+		elif [ "$PI_TYPE" = "2B" ]; then
+			PI_SERIES=Pi2
+		elif [ "$PI_TYPE" = "1A+" ] || [ "$PI_TYPE" = "1B+" ]; then
+			PI_SERIES=Pi1+
+		elif [ "$PI_TYPE" = "1A" ] || [ "$PI_TYPE" = "1B" ] || [ "$PI_TYPE" = "CM1" ]; then
+			PI_SERIES=Pi1
+		elif [ "$PI_TYPE" = "Internal use only" ] || [ "$PI_TYPE" = "Alpha (early prototype)" ]; then
+			PI_SERIES=X
+		else
+			echo "Error: Could not identify Pi series.">&2
+			run_giveup
+		fi
+		echo -e "\nThis Pi is part of the ${PI_SERIES} series."
 }
 
 function run_giveup()  # If our script failed at any critical stages, notify the user and quit
@@ -868,7 +1795,8 @@ function run_giveup()  # If our script failed at any critical stages, notify the
     echo ""
     echo "Winelink installation failed."
     echo ""
-    echo "For help, please reference the 'winelink.log' file"
+    echo -e "If a download failed, please check your internet connection and try re-running \nthe script."
+    echo "For help, please reference the '${HOME}/winelink\winelink.log' file"
     echo "You can also open an issue on github.com/WheezyE/Winelink/"
     echo ""
     exit


### PR DESCRIPTION
install_winelink.sh
	Add omni-system Wine installer
	 - Allow run_greeting() to display different header depending on CPU/OS (install time, space requirements, system info).
	 - Create run_rpifinder function that detects user's RPi hardware configuration
	 - Add Pi4/3 ARM32/ARM64 Wine install methods
		> Add Pi3 32-bit kernelswap method (thank you Botspot!)
		> Add warning for pi3customkernelswap in case configs module not found
		> Increase swap file size and throttle CPU a bit while compiling to prevent Pi3B+ crashes (from running out of RAM).
		> Add i386-wine armhf dependencies to Pi4/3 64-bit RPiOS install methods
		> Upload a pre-compiled box86 ed8e01ea (used RPI4 flag to compile) including bundled libraries and binfmt (use this for all Pi3-4 installs).
		> Make sure `/usr/lib/i386-linux-gnu/` exists on Pi during box86 download/install
	 - Add Debian & Ubuntu x64 Wine install methods
		> Ensure Ubuntu has updated system time & certs for WineHQ repo verification
		> Enable access to USB CAT control: On x86/x64 Linux distro's add the user to the dialout group to give them access to radio USB CAT control ports.
		> Ensure Debian has updated system time & certs for WineHQ repo verification (install NTP if it's not installed yet)
		> Fix bug found in the winehq-bullseye.sources file for x86/64 installs
	 - Add user instructions for enabling sudoer access to user accounts on x86/x64
		> Move pre-installation higher up (so that users without sudoer access don't have to type in their sudo password lots of times).

	Shorten script header comments
	Update intro screen & in-script notes.
	Have installation check to see if user has enough space to install Winelink
	Make script more silent (winelink cleanup, wget)
	Clean up RMS Express logs from ~ on uninstall/reinstall
	Use wine-mono 7.2.0 official winehq download link
	Have the reset wine script reset VARA HF/FM/sat waterfall and graphics
	Disable VARA SAT since it causes some issues and I'm pretty sure most people don't need it
	Add 7zip install to run_installahk() for #43
	Simplify/rewrite `run_installwine()` function as `run_sideloadi386wine()`
	Remove unused methods
	Fix terminal output formatting a bit
	Bump version to 0.97a

Readme:
	Organize sections into collapsible subsections
	Add new goals for Android