### PR TITLE
add codename detection to fix distribution fails

### DIFF
--- a/install_winelink.sh
+++ b/install_winelink.sh
@@ -182,6 +182,9 @@ function run_main()
 			#Install wine (note: packages are called "wine-stable", not "winehq-stable" like in the Wine wiki).
 			sudo dpkg --add-architecture i386 # also install wine32 using multi-arch
 			sudo apt-key del "D43F 6401 4536 9C51 D786 DDEA 76F1 A20F F987 672F" #apt-key is deprecated, but this step is here as a hotfix in case distro has an old winehq gpg key installed
+			sudo mkdir -pm755 /etc/apt/keyrings
+			sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key || { echo "unable to download winehq gpg key!" && run_giveup; }
+			
 			sudo wget -O /usr/share/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key || { echo "unable to download winehq gpg key!" && run_giveup; }
 			sudo wget -P /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/${VERSION_CODENAME}/winehq-${VERSION_CODENAME}.sources || { echo "unable to download winehq sources file!" && run_giveup; }
 			sudo sed -i 's&/etc/apt/keyrings/winehq-archive.key&/usr/share/keyrings/winehq-archive.key&g' /etc/apt/sources.list.d/winehq-${VERSION_CODENAME}.sources #fix bug found in the winehq-bullseye.sources file present 09/11/2022

--- a/install_winelink.sh
+++ b/install_winelink.sh
@@ -231,11 +231,23 @@ function run_main()
 
 				#Install wine (note: In Ubuntu, packages are called "wine-stable", not "winehq-stable" like in the Wine wiki).
 				sudo dpkg --add-architecture i386 #Install procedure last reviewed 09/07/2022 - ejw
-				sudo wget -O /usr/share/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key || { echo "unable to download winehq gpg key!" && run_giveup; }
-				sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/${UBUNTU_CODENAME}/winehq-${UBUNTU_CODENAME}.sources || { echo "unable to download winehq sources file!" && run_giveup; }
+				
+				# 7-11-2022 updated to install doc https://wiki.winehq.org/Ubuntu
+				sudo mkdir -pm755 /etc/apt/keyrings
+				sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key || { echo "unable to download winehq gpg key!" && run_giveup; }
+				if [ $ID == "ubuntu" ];then
+					sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/${UBUNTU_CODENAME}/winehq-${UBUNTU_CODENAME}.sources || { echo "unable to download ubuntu winehq sources file!" && run_giveup; }
+				fi
 				sudo apt-get update
-				#sudo apt-get install --install-recommends wine-stable -y  || { echo "wine instllation failed!" && run_giveup; } #note: no winehq-stable package for ubuntu. Symlinks are still created though#sudo apt-get install --install-recommends wine-stable -y  || { echo "wine instllation failed!" && run_giveup; } #note: no winehq-stable package for ubuntu. Symlinks are still created though
-				sudo apt-get install --install-recommends winehq-devel -y  || { echo "wine instllation failed!" && run_giveup; } #note: for some reason wine-stable lags far behind on ubuntu
+
+				if [ $ID == "linuxmint" ];then
+					#mint package
+					sudo apt-get install --install-recommends wine-installer -y || { echo "wine installation on mint failed!" && run_giveup; }
+				else
+					#ubuntu
+					sudo apt-get install --install-recommends winehq-devel -y  || { echo "wine insallation on ubuntu failed!" && run_giveup; } #note: for some reason wine-stable lags far behind on ubuntu
+					#sudo apt-get install --install-recommends wine-stable -y  || { echo "wine instllation failed!" && run_giveup; } #note: no winehq-stable package for ubuntu. Symlinks are still created though#sudo apt-get install --install-recommends wine-stable -y  || { echo "wine instllation failed!" && run_giveup; } #note: no winehq-stable package for ubuntu. Symlinks are still created though
+				fi
 
 				#Add the user to the USB dialout group so that they can access radio USB CAT control later.
 				sudo usermod -a -G dialout $USER

--- a/install_winelink.sh
+++ b/install_winelink.sh
@@ -911,7 +911,7 @@ function run_installahk()
     mkdir downloads 2>/dev/null; cd downloads
         # Download AutoHotKey
 	echo -e "\n${GREENTXT}Downloading AutoHotkey . . .${NORMTXT}\n"
-        wget -q https://github.com/AutoHotkey/AutoHotkey/releases/download/v1.0.48.05/AutoHotkey104805_Install.exe || { echo "AutoHotkey download failed!" && run_giveup; }
+        wget -q https://www.autohotkey.com/download/1.0/AutoHotkey104805_Install.exe || { echo "AutoHotkey download failed!" && run_giveup; }
         7z x AutoHotkey104805_Install.exe AutoHotkey.exe -y -bsp0 -bso0
 	mkdir ${HOME}/winelink 2>/dev/null
 	mkdir ${AHK}


### PR DESCRIPTION
suggestion to handle mint and ubuntu differences on install. mint has a package installer dedicated for codename management. tested against 2(2x.x)Mint|Ubuntu with success on all platforms.