### PR TITLE
varac download fix

### DIFF
--- a/install_winelink.sh
+++ b/install_winelink.sh
@@ -1038,7 +1038,7 @@ function run_installvarAC()  # Download/extract/install varAC chat app
     mkdir downloads 2>/dev/null; cd downloads
         # Download varAC linux working version 6.1 (static Link as no dynamic link known at the moment)
             echo -e "\n${GREENTXT}Downloading and installing VarAC . . .${NORMTXT}\n"
-            wget -q https://varac.hopp.to/varac_latest || { echo "VarAC download failed!" && run_giveup; }
+            wget -q -r -l1 -np -nd https://288b5dcd-0898-4460-b829-4a40f1724acf.usrfiles.com/archives/288b5d_c0231e0495a34733b30bdd5155276fb3.zip -O varac_latest || { echo "VarAC download failed!" && run_giveup; }
             
         # Extract/install VarAC
             mkdir -p ${HOME}/.wine/drive_c/VarAC


### PR DESCRIPTION
https://varac.hopp.to/varac_latest  appears to be offline

should this hard fail?
also I would request not trying to setup and load the dialog as part of the script wait till its used. 
this app shouldn't kill the overall project